### PR TITLE
modifications in preparation for first alpha release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,71 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+#Ipython Notebook
+.ipynb_checkpoints
+
+# vi
+.*.swp
+
+.DS_Store
+
+# example output
+data/tiny-test/mixing_proportions
+data/tiny-test/source_loo

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ script:
   - nosetests
   - flake8 sourcetracker setup.py
   - sourcetracker2 gibbs --help
+  - cd data/tiny-test/
+  - sourcetracker2 gibbs -i otu_table.biom -m map.txt -o example1/
+  - sourcetracker2 gibbs -i otu_table.biom -m alt-map.txt -o example2/ --source_sink_column source-or-sink --source_column_value src --sink_column_value snk --source_category_column sample-type

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 SourceTracker was originally described in [Knights et al., 2011](http://www.ncbi.nlm.nih.gov/pubmed/21765408).
 If you use this package, please cite the original SourceTracker paper linked
-above.
+above pending publication of SourceTracker 2.
 
 # Documentation
 
@@ -56,8 +56,8 @@ to activate your SourceTracker 2 environment.
 
 # Theory
 
-This readme describes some of the basic theory for use of SourceTracker2. For
-more theory and a visual walkthrough, please see the [juypter notebook](https://github.com/biota/SourceTracker_rc/blob/master/ipynb/Sourcetracking%20using%20a%20Gibbs%20Sampler.ipynb).
+This document describes some of the basic theory for use of SourceTracker2. For
+more theory and a visual walkthrough, please see the [Juypter notebook](https://github.com/biota/SourceTracker_rc/blob/master/ipynb/Sourcetracking%20using%20a%20Gibbs%20Sampler.ipynb).
 
 There are main two ways to use this script:  
  (1) Estimating the proportions of different (microbial) sources to a sample of
@@ -138,29 +138,32 @@ These usage examples expect that you are in the directory
 `sourcetracker2/data/tiny-test/`
 
 **Calculate the proportion of each source in each sink**  
-`sourcetracker2 gibbs -i otu_table.biom -m map.txt -o mixing_proportions/`
+`sourcetracker2 gibbs -i otu_table.biom -m map.txt -o example1/`
+
+**Calculate the proportion of each source in each sink using an alternate sample metadata mapping file where samples are described differently.**  
+`sourcetracker2 gibbs -i otu_table.biom -m alt-map.txt -o example2/ --source_sink_column source-or-sink --source_column_value src --sink_column_value snk --source_category_column sample-type`
 
 **Calculate the class label (i.e. 'Env') of each source using a leave one out
 strategy**    
-`sourcetracker2 gibbs -i otu_table.biom -m map.txt --loo -o source_loo/`
+`sourcetracker2 gibbs -i otu_table.biom -m map.txt --loo -o example3/`
 
 **Calculate the proportion of each source in each sink, using 100 burnins**  
-`sourcetracker2 gibbs -i otu_table.biom -m map.txt -o mixing_proportions/ --burnin 100`
+`sourcetracker2 gibbs -i otu_table.biom -m map.txt -o example4/ --burnin 100`
 
 **Calculate the proportion of each source in each sink, using a sink
 rarefaction depth of 2500**    
-`sourcetracker2 gibbs -i otu_table.biom -m map.txt -o mixing_proportions/ --sink_rarefaction_depth 2500`
+`sourcetracker2 gibbs -i otu_table.biom -m map.txt -o example5/ --sink_rarefaction_depth 2500`
 
 **Calculate the proportion of each source in each sink, using ipyparallel to run in parallel with 5 jobs**  
-`sourcetracker2 gibbs -i otu_table.biom -m map.txt -o mixing_proportions/ --jobs 5`
+`sourcetracker2 gibbs -i otu_table.biom -m map.txt -o example6/ --jobs 5`
 
 # Miscellaneous
 
 The current implementation of SourceTracker 2 does not contain functionality for
-visualization of results or autotuning of the parameters (`alpha1`, `alpha1`,
+visualization of results or auto-tuning of the parameters (`alpha1`, `alpha1`,
 etc.). For an example of how you might visualize the data, please see
-this [juypter notebook](https://github.com/biota/SourceTracker2/blob/master/ipynb/Visualizing%20results.ipynb).
-For autotuning functionality, please see the original R code.
+this [Juypter notebook](https://github.com/biota/SourceTracker2/blob/master/ipynb/Visualizing%20results.ipynb).
+For auto-tuning functionality, please see the original R code.
 
 Like the old SourceTracker, SourceTracker2 rarifies the source environments it
 collapses by default.

--- a/data/tiny-test/alt-map.txt
+++ b/data/tiny-test/alt-map.txt
@@ -1,0 +1,1 @@
+#SampleID	source-or-sink	sample-types9	src	sewages8	src	sewages3	snk	pond1s2	snk	pond2s1	snk	pond3s0	snk	pond4s7	src	drainwaters6	snk	pond5s5	src	seawaters4	src	seawater

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ setup(
     classifiers=classifiers,
     entry_points='''
         [console_scripts]
-        sourcetracker2=sourcetracker.cli:cli
+        sourcetracker2=sourcetracker._cli:cli
         ''')

--- a/sourcetracker/_cli/__init__.py
+++ b/sourcetracker/_cli/__init__.py
@@ -16,4 +16,4 @@ from sourcetracker import __version__
 def cli():
     pass
 
-import_module('sourcetracker.cli.gibbs')
+import_module('sourcetracker._cli.gibbs')

--- a/sourcetracker/_cli/gibbs.py
+++ b/sourcetracker/_cli/gibbs.py
@@ -19,13 +19,11 @@ import subprocess
 import time
 from biom import load_table
 from biom.table import Table
-from sourcetracker.cli import cli
-from sourcetracker.sourcetracker import (parse_mapping_file, collapse_sources,
-                                         sinks_and_sources,
-                                         _cli_sync_biom_and_sample_metadata,
-                                         _cli_collate_results, _cli_loo_runner,
-                                         _cli_sink_source_prediction_runner,
-                                         subsample_sources_sinks)
+from sourcetracker._cli import cli
+from sourcetracker._sourcetracker import (
+    parse_mapping_file, collapse_sources, sinks_and_sources,
+    _cli_sync_biom_and_sample_metadata, _cli_collate_results, _cli_loo_runner,
+    _cli_sink_source_prediction_runner, subsample_sources_sinks)
 from ipyparallel import Client
 
 
@@ -35,19 +33,20 @@ from ipyparallel import Client
               help='Path to input BIOM table.')
 @click.option('-m', '--mapping_fp', required=True,
               type=click.Path(exists=True, dir_okay=False),
-              help='Path to input category mapping file (sample metadata).')
+              help='Path to sample metadata mapping file.')
 @click.option('-o', '--output_dir', required=True,
               type=click.Path(exists=False, dir_okay=False),
               help='Path to the output directory to be created.')
 @click.option('--loo', required=False, default=False, is_flag=True,
+              show_default=True,
               help=('Classify each sample in `sources` using a leave-one-out '
                     'strategy. Replicates -s option in Knights et al. '
                     'sourcetracker.'))
 @click.option('--jobs', required=False, default=1,
-              type=click.INT,
+              type=click.INT, show_default=True,
               help='Number of processes to launch.')
 @click.option('--alpha1', required=False, default=.001,
-              type=click.FLOAT,
+              type=click.FLOAT, show_default=True,
               help=('Prior counts of each species in the training '
                     'environments. Higher values decrease the trust in the '
                     'training environments, and make the source environment '
@@ -58,41 +57,41 @@ from ipyparallel import Client
                     'biological samples are available from a source '
                     'environment. A more conservative value would be 0.01.'))
 @click.option('--alpha2', required=False, default=.001,
-              type=click.FLOAT,
+              type=click.FLOAT, show_default=True,
               help=('Prior counts of each species in Unknown environment. '
                     'Higher values make the Unknown environment smoother and '
                     'less prone to overfitting given a training sample.'))
 @click.option('--beta', required=False, default=10,
-              type=click.INT,
+              type=click.INT, show_default=True,
               help=('Count to be added to each species in each environment, '
                     'including `unknown`.'))
 @click.option('--source_rarefaction_depth', required=False, default=1000,
-              type=click.INT,
+              type=click.INT, show_default=True,
               help=('Depth at which to rarify sources. If 0, no '
                     'rarefaction performed.'))
 @click.option('--sink_rarefaction_depth', required=False, default=1000,
-              type=click.INT,
+              type=click.INT, show_default=True,
               help=('Depth at which to rarify sinks. If 0, no '
                     'rarefaction performed.'))
 @click.option('--restarts', required=False, default=10,
-              type=click.INT,
+              type=click.INT, show_default=True,
               help=('Number of independent Markov chains to grow. '
                     '`draws_per_restart` * `restarts` gives the number of '
                     'samplings of the mixing proportions that will be '
                     'generated.'))
 @click.option('--draws_per_restart', required=False, default=1,
-              type=click.INT,
+              type=click.INT, show_default=True,
               help=('Number of times to sample the state of the Markov chain '
                     'for each independent chain grown.'))
 @click.option('--burnin', required=False, default=100,
-              type=click.INT,
+              type=click.INT, show_default=True,
               help=('Number of passes (withdarawal and reassignment of every '
                     'sequence in the sink) that will be made before a sample '
                     '(draw) will be taken. Higher values allow more '
                     'convergence towards the true distribtion before draws '
                     'are taken.'))
 @click.option('--delay', required=False, default=10,
-              type=click.INT,
+              type=click.INT, show_default=True,
               help=('Number passes between each sampling (draw) of the '
                     'Markov chain. Once the burnin passes have been made, a '
                     'sample will be taken every `delay` number of passes. '
@@ -100,15 +99,33 @@ from ipyparallel import Client
                     'the impact of correlation between adjacent states of the '
                     'Markov chain.'))
 @click.option('--cluster_start_delay', required=False, default=25,
-              type=click.INT,
+              type=click.INT, show_default=True,
               help=('When using multiple jobs, the script has to start an '
                     '`ipcluster`. If ipcluster does not recognize that it '
                     'has been successfully started, the jobs will not be '
                     'successfully launched. If this is happening, increase '
                     'this parameter.'))
+@click.option('--source_sink_column', required=False, default='SourceSink',
+              type=click.STRING, show_default=True,
+              help=('Sample metadata column indicating which samples should be'
+                    ' treated as sources and which as sinks.'))
+@click.option('--source_column_value', required=False, default='source',
+              type=click.STRING, show_default=True,
+              help=('Value in source_sink_column indicating which samples '
+                    'should be treated as sources.'))
+@click.option('--sink_column_value', required=False, default='sink',
+              type=click.STRING, show_default=True,
+              help=('Value in source_sink_column indicating which samples '
+                    'should be treated as sinks.'))
+@click.option('--source_category_column', required=False, default='Env',
+              type=click.STRING, show_default=True,
+              help=('Sample metadata column indicating the type of each '
+                    'source sample.'))
 def gibbs(table_fp, mapping_fp, output_dir, loo, jobs, alpha1, alpha2, beta,
           source_rarefaction_depth, sink_rarefaction_depth,
-          restarts, draws_per_restart, burnin, delay, cluster_start_delay):
+          restarts, draws_per_restart, burnin, delay, cluster_start_delay,
+          source_sink_column, source_column_value, sink_column_value,
+          source_category_column):
     '''Gibb's sampler for Bayesian estimation of microbial sample sources.
 
     For details, see the project README file.
@@ -141,7 +158,9 @@ def gibbs(table_fp, mapping_fp, output_dir, loo, jobs, alpha1, alpha2, beta,
 
     # Parse the mapping file and options to get the samples requested for
     # sources and sinks.
-    source_samples, sink_samples = sinks_and_sources(sample_metadata)
+    source_samples, sink_samples = sinks_and_sources(
+        sample_metadata, column_header=source_sink_column,
+        source_value=source_column_value, sink_value=sink_column_value)
 
     # If we have no source samples neither normal operation or loo will work.
     # Will also likely get strange errors.
@@ -152,7 +171,8 @@ def gibbs(table_fp, mapping_fp, output_dir, loo, jobs, alpha1, alpha2, beta,
     # Prepare the 'sources' matrix by collapsing the `source_samples` by their
     # metadata values.
     sources_envs, sources_data = collapse_sources(source_samples,
-                                                  sample_metadata, 'Env',
+                                                  sample_metadata,
+                                                  source_category_column,
                                                   biom_table, sort=True)
 
     # Rarefiy data if requested.
@@ -164,7 +184,7 @@ def gibbs(table_fp, mapping_fp, output_dir, loo, jobs, alpha1, alpha2, beta,
     # Build function that require only a single parameter -- sample -- to
     # enable parallel processing if requested.
     if loo:
-        f = partial(_cli_loo_runner, source_category='Env',
+        f = partial(_cli_loo_runner, source_category=source_category_column,
                     alpha1=alpha1, alpha2=alpha2, beta=beta,
                     restarts=restarts, draws_per_restart=draws_per_restart,
                     burnin=burnin, delay=delay,

--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -12,7 +12,7 @@ from __future__ import division
 import os
 from copy import copy
 import numpy as np
-from skbio.stats._subsample import subsample_counts
+from skbio.stats import subsample_counts
 import pandas as pd
 from functools import partial
 from biom.table import Table
@@ -213,23 +213,23 @@ class Sampler(object):
 
         Attributes
         ----------
-        self.sink_data : np.array
+        sink_data : np.array
             Sink data (see Parameters).
-        self.num_sources : int
+        num_sources : int
             Number of source environments.
-        self.num_features : int
+        num_features : int
             Number of features.
-        self.sum : int
+        sum : int
             Total number of sequences in sink sample.
-        self.taxon_sequence : np.array
+        taxon_sequence : np.array
             Bookkeeping array that contains an entry for each sequence so that
             their source assignments can be manipulated. Not set until
             `generate_taxon_sequence` is called.
-        self.seq_env_assignments : np.array
+        seq_env_assignments : np.array
             Vector of integers where the ith entry is the source environment
             index of the ith sequence. Not set until
             `generate_environment_assignments` is called.
-        self.envcounts : np.array
+        envcounts : np.array
             Total number of sequences assigned to each source environment. Not
             set until `generate_environment_assignments` is called.
         """
@@ -312,33 +312,33 @@ class ConditionalProbability(object):
 
         Attributes
         ----------
-        self.m_xivs : np.array
+        m_xivs : np.array
             This is an exact copy of the source_data passed when the function
             is initialized. It is referenced as m_xivs because m_xiv is the
             [v, xi] entry of the source data. In other words, the count of the
             xith feature in the vth environment.
-        self.m_vs : np.array
+        m_vs : np.array
             The row sums of self.m_xivs. This is referenced as m_v in [1]_.
-        self.V : int
+        V : int
             Number of environments (includes both known sources and the
             'unknown' source).
-        self.tau : int
+        tau : int
             Number of features.
-        self.joint_probability : np.array
+        joint_probability : np.array
             The joint conditional distribution. Until the `precalculate` method
             is called, this will be uniformly zero.
-        self.n : int
+        n : int
             Number of sequences in the sink.
-        self.known_p_tv : np.array
+        known_p_tv : np.array
             An array giving the precomputable parts of the probability of
             finding the xith taxon in the vth environment given the known
             sources, aka p_tv in the R implementation. Rows are (known)
             sources, columns are features, shape is (V-1, tau).
-        self.denominator_p_v : float
+        denominator_p_v : float
             The denominator of the calculation for finding the probability of
             a sequence being in the vth environment given the training data
             (source data).
-        self.known_source_cp : np.array
+        known_source_cp : np.array
             All precomputable portions of the conditional probability array.
             Dimensions are the same as self.known_p_tv.
 
@@ -618,7 +618,8 @@ def gibbs_sampler(cp, sink, restarts, draws_per_restart, burnin, delay):
     return mixing_proportions, calculated_assignments
 
 
-def sinks_and_sources(sample_metadata):
+def sinks_and_sources(sample_metadata, column_header="SourceSink",
+                      source_value='source', sink_value='sink'):
     '''Return lists of source and sink samples.
 
     Notes
@@ -630,7 +631,15 @@ def sinks_and_sources(sample_metadata):
     Parameters
     ----------
     sample_metadata : dict
-        Dictionary containing sample metadata. Format is common QIIME format.
+        Dictionary containing sample metadata in QIIME 1 sample metadata
+        mapping file format.
+    column_header : str, optional
+        Column in the mapping file that describes where a sample is a source
+        or a sink.
+    source_value : str, optional
+        Value that indicates a sample is a source.
+    sink_value : str, optional
+        Value that indicates a sample is a sink.
 
     Returns
     -------
@@ -642,9 +651,9 @@ def sinks_and_sources(sample_metadata):
     sink_samples = []
     source_samples = []
     for sample, md in sample_metadata.items():
-        if md['SourceSink'] == 'sink':
+        if md[column_header] == sink_value:
             sink_samples.append(sample)
-        elif md['SourceSink'] == 'source':
+        elif md[column_header] == source_value:
             source_samples.append(sample)
         else:
             pass
@@ -861,17 +870,19 @@ def _cli_loo_runner(sample, source_category, alpha1, alpha2, beta, restarts,
 
 def _gibbs(source_df, sink_df, alpha1, alpha2, beta, restarts,
            draws_per_restart, burnin, delay, cluster=None):
-    '''Private method for one-line calls of Gibb's sampling.
+    '''Gibb's sampling API
 
     Notes
     -----
-    This function exists to allow one-line calls to source/sink prediction.
+    This function exists to allow API calls to source/sink prediction.
     This function currently does not support LOO classification. It is a
-    private method meant to be used only by advanced users who know what they
-    want to automate.
+    candidate public API call. You can track progress on this via
+    https://github.com/biota/sourcetracker2/issues/31
 
     Parameters that are not described in this function body are described
-    elsewhere in this library (e.g. alpha1, alpha2, etc.)
+    elsewhere in this library (e.g. alpha1, alpha2, etc.).
+    # TODO: document API fully - users won't be able to access this information
+    # without access to private functionality.
 
     Warnings
     --------
@@ -940,7 +951,7 @@ def _gibbs(source_df, sink_df, alpha1, alpha2, beta, restarts,
 
     Call without a cluster
     >>> mp, mps = _gibbs(source_df, sink_df, alpha1, alpha2, beta, restarts,
-                         draws_per_restart, burnin, delay, cluster=None)
+                         draws_per_restart, burnin, delay)
 
     Start a cluster and call the function.
     >>> jobs = 4

--- a/sourcetracker/tests/test_sourcetracker.py
+++ b/sourcetracker/tests/test_sourcetracker.py
@@ -11,13 +11,11 @@ from __future__ import division
 from unittest import TestCase, main
 import numpy as np
 from biom.table import Table
-from sourcetracker.sourcetracker import (parse_mapping_file, collapse_sources,
-                                         ConditionalProbability, gibbs_sampler,
-                                         Sampler, sinks_and_sources,
-                                         _cli_sync_biom_and_sample_metadata,
-                                         _cli_single_sample_formatter,
-                                         _cli_collate_results,
-                                         subsample_sources_sinks)
+from sourcetracker._sourcetracker import (
+    parse_mapping_file, collapse_sources, ConditionalProbability,
+    gibbs_sampler, Sampler, sinks_and_sources,
+    _cli_sync_biom_and_sample_metadata, _cli_single_sample_formatter,
+    _cli_collate_results, subsample_sources_sinks)
 
 
 class TestPreparationFunctions(TestCase):
@@ -317,6 +315,23 @@ class TestCLIFunctions(TestCase):
             sinks_and_sources(self.sample_metadata_3)
         exp_source_samples = ['s1', 's5', 's0', 's2', 's100']
         exp_sink_samples = []
+        self.assertEqual(set(exp_sink_samples), set(obs_sink_samples))
+        self.assertEqual(set(exp_source_samples), set(obs_source_samples))
+
+    def test_sinks_and_sources_alt_strings(self):
+
+        metadata = {
+           's1':   {'source-or-sink': '--source!'},
+           's2':   {'source-or-sink': '--sink!'},
+           's5':   {'source-or-sink': '--source!'},
+           's0':   {'source-or-sink': '--source!'},
+           's100': {'source-or-sink': '--sink!'}}
+
+        obs_source_samples, obs_sink_samples = sinks_and_sources(
+            metadata, column_header='source-or-sink', source_value='--source!',
+            sink_value='--sink!')
+        exp_source_samples = ['s1', 's5', 's0']
+        exp_sink_samples = ['s2', 's100']
         self.assertEqual(set(exp_sink_samples), set(obs_sink_samples))
         self.assertEqual(set(exp_source_samples), set(obs_source_samples))
 


### PR DESCRIPTION
* Command line interface now takes four new parameters (``--source_sink_column``, ``--source_column_value``,  ``--sink_column_value``, ``source_category_column``) which remove requirements on mapping file values. Defaults are still the same, so no changes to command line interface or APIs.

* The API is now more formally privatized by having the file names start with ``_``. This makes it clear to any advanced users that no part of the API should currently be considered public or stable. If you were previously using ``from sourcetracker.sourcetracker import _gibbs``, you should now update that to ``from sourcetracker._sourcetracker import _gibbs``. 

* Travis now runs a couple more commands. 

* Various other small clean-ups throughout. 

@lkursell, @johnchase, @wdwvt1, it'd be great to have one of you take a quick look at this. If all is good I can create the release tomorrow morning. 