### PR TITLE
ENH: adds API for comparing sourcetracker results

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
     test_suite='nose.collector',
     packages=find_packages(),
     install_requires=['numpy', 'h5py', 'biom-format >= 2.1.5, < 2.2.0',
-                      'click', 'ipyparallel', 'scikit-bio', 'pandas'],
+                      'click', 'ipyparallel', 'scikit-bio', 'pandas',
+                      'scipy >= 0.18.0'],
     classifiers=classifiers,
     entry_points='''
         [console_scripts]

--- a/sourcetracker/__init__.py
+++ b/sourcetracker/__init__.py
@@ -7,5 +7,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from sourcetracker._compare import compare_sinks, compare_sink_metrics
+
 __version__ = '2.0.1-dev'
 _readme_url = "https://github.com/biota/sourcetracker2/blob/master/README.md"
+
+__all__ = ['compare_sinks', 'compare_sink_metrics']

--- a/sourcetracker/_compare.py
+++ b/sourcetracker/_compare.py
@@ -62,6 +62,8 @@ def compare_sinks(observed, expected, metric):
 
 
 def _validate_dataframes(observed, expected):
+    """ Confirm index and columns contain the same values
+    """
     if set(observed.index) != set(expected.index):
         raise ValueError('Sinks in observed and expected results must be '
                          'identical.')

--- a/sourcetracker/_compare.py
+++ b/sourcetracker/_compare.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, Biota Technology.
+# www.biota.com
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import pandas as pd
+import numpy as np
+import scipy.stats
+import scipy.spatial
+
+
+def compare_sink_metrics():
+    return list(sorted(_compare_sinks_metrics.keys()))
+
+
+def compare_sinks(observed, expected, metric):
+    """ Compare the mix proportions for a collection of sinks
+
+    Parameters
+    ----------
+    observed: pd.DataFrame
+        Observed mix proportions where sinks are indices and sources are
+        columns.
+    observed: pd.DataFrame
+        Expected mix proportions where sinks are indices and sources are
+        columns.
+    metric: str
+        The metric to use for comparing sinks.
+
+    Returns
+    -------
+    pd.DataFrame
+        Comparison results where indices are sinks and columns indicate
+        similarity or difference, depending on the metric. The specific
+        columns that are included will be metric-dependent.
+
+    See Also
+    --------
+    sourcetracker._compare.compare_sink_metrics
+
+    """
+
+    if metric not in _compare_sinks_metrics:
+        raise KeyError("%s is not a known metric. Known metrics are: %s."
+                       % (metric, ', '.join(_compare_sinks_metrics)))
+    else:
+        metric_fn = _compare_sinks_metrics[metric]
+
+    _validate_dataframes(observed, expected)
+
+    # Depending on the compare function being called, these sorts won't always
+    # be necessary, but it's a nice catch to have since we then don't need to
+    # confirm that all compare functions do this. I expect that these should
+    # be quick since the size of results being compared likely isn't very big
+    # but we can revisit if this is a bottleneck.
+    return metric_fn(observed.sort_index(), expected.sort_index())
+
+
+def _validate_dataframes(observed, expected):
+    if set(observed.index) != set(expected.index):
+        raise ValueError('Sinks in observed and expected results must be '
+                         'identical.')
+
+    if set(observed.columns) != set(expected.columns):
+        raise ValueError('Sources in observed and expected results must be '
+                         'identical.')
+
+
+def _spearman(observed, expected):
+    results = []
+    for id_ in observed.index:
+        rho, p = scipy.stats.spearmanr(observed.loc[id_], expected.loc[id_])
+        results.append((rho, p))
+    return pd.DataFrame(results, index=observed.index,
+                        columns=['Spearman rho', 'p'])
+
+
+def _pearson(observed, expected):
+    results = []
+    for id_ in observed.index:
+        rho, p = scipy.stats.pearsonr(observed.loc[id_], expected.loc[id_])
+        results.append((rho, p))
+    return pd.DataFrame(results, index=observed.index,
+                        columns=['Pearson r', 'p'])
+
+
+def _euclidean(observed, expected):
+    results = []
+    for id_ in observed.index:
+        d = scipy.spatial.distance.euclidean(observed.loc[id_],
+                                             expected.loc[id_])
+        results.append(d)
+    return pd.DataFrame(results, index=observed.index,
+                        columns=['Euclidean distance'])
+
+
+def _absolute_difference(observed, expected):
+    results = []
+    for id_ in observed.index:
+        results.append(np.abs(observed.loc[id_] - expected.loc[id_]))
+    return pd.DataFrame(results, index=observed.index,
+                        columns=observed.columns)
+
+
+_compare_sinks_metrics = {'spearman': _spearman, 'pearson': _pearson,
+                          'euclidean': _euclidean,
+                          'absolute_difference': _absolute_difference}

--- a/sourcetracker/tests/test_compare.py
+++ b/sourcetracker/tests/test_compare.py
@@ -13,7 +13,8 @@ import unittest
 import pandas as pd
 from skbio.util import assert_data_frame_almost_equal
 
-from sourcetracker._compare import compare_sinks, compare_sink_metrics
+from sourcetracker import compare_sinks, compare_sink_metrics
+from sourcetracker._compare import _validate_dataframes
 
 
 class CompareSinksTests(unittest.TestCase):
@@ -44,6 +45,62 @@ class CompareSinksTests(unittest.TestCase):
                             'sink5': 0.1238333602454384,
                             'sink6': 0.17419230621125187}}
         self.mpm1 = pd.DataFrame(mpm1)
+
+    def test_validate_dataframes_valid(self):
+        df1 = {'Unknown': {'sink1': 0.25, 'sink2': 0.25},
+               'Source1': {'sink1': 0.50, 'sink2': 0.25},
+               'Source2': {'sink1': 0.25, 'sink2': 0.25}}
+        df1 = pd.DataFrame(df1)
+        df2 = {'Unknown': {'sink1': 0.1, 'sink2': 0.25},
+               'Source1': {'sink1': 0.1, 'sink2': 0.25},
+               'Source2': {'sink1': 0.8, 'sink2': 0.25}}
+        df2 = pd.DataFrame(df2)
+        _validate_dataframes(df1, df2)
+
+    def test_validate_dataframes_invalid_sources(self):
+        df1 = {'Hello': {'sink1': 0.25, 'sink2': 0.25},
+               'Source1': {'sink1': 0.50, 'sink2': 0.25},
+               'Source2': {'sink1': 0.25, 'sink2': 0.25}}
+        df1 = pd.DataFrame(df1)
+        df2 = {'Unknown': {'sink1': 0.1, 'sink2': 0.25},
+               'Source1': {'sink1': 0.1, 'sink2': 0.25},
+               'Source2': {'sink1': 0.8, 'sink2': 0.25}}
+        df2 = pd.DataFrame(df2)
+        with self.assertRaises(ValueError):
+            _validate_dataframes(df1, df2)
+
+        df1 = {'Source1': {'sink1': 0.50, 'sink2': 0.25},
+               'Source2': {'sink1': 0.50, 'sink2': 0.25}}
+        df1 = pd.DataFrame(df1)
+        df2 = {'Unknown': {'sink1': 0.1, 'sink2': 0.25},
+               'Source1': {'sink1': 0.1, 'sink2': 0.25},
+               'Source2': {'sink1': 0.8, 'sink2': 0.25}}
+        df2 = pd.DataFrame(df2)
+        with self.assertRaises(ValueError):
+            _validate_dataframes(df1, df2)
+
+    def test_validate_dataframes_invalid_sinks(self):
+        df1 = {'Unknown': {'sink1': 0.25, 'sink3': 0.25},
+               'Source1': {'sink1': 0.50, 'sink3': 0.25},
+               'Source2': {'sink1': 0.25, 'sink3': 0.25}}
+        df1 = pd.DataFrame(df1)
+        df2 = {'Unknown': {'sink1': 0.1, 'sink2': 0.25},
+               'Source1': {'sink1': 0.1, 'sink2': 0.25},
+               'Source2': {'sink1': 0.8, 'sink2': 0.25}}
+        df2 = pd.DataFrame(df2)
+        with self.assertRaises(ValueError):
+            _validate_dataframes(df1, df2)
+
+        df1 = {'Unknown': {'sink1': 0.25},
+               'Source1': {'sink1': 0.50},
+               'Source2': {'sink1': 0.50}}
+        df1 = pd.DataFrame(df1)
+        df2 = {'Unknown': {'sink1': 0.1, 'sink2': 0.25},
+               'Source1': {'sink1': 0.1, 'sink2': 0.25},
+               'Source2': {'sink1': 0.8, 'sink2': 0.25}}
+        df2 = pd.DataFrame(df2)
+        with self.assertRaises(ValueError):
+            _validate_dataframes(df1, df2)
 
     def test_compare_sink_metrics(self):
         self.assertEqual(compare_sink_metrics(),

--- a/sourcetracker/tests/test_compare.py
+++ b/sourcetracker/tests/test_compare.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, Biota Technology.
+# www.biota.com
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+import pandas as pd
+from skbio.util import assert_data_frame_almost_equal
+
+from sourcetracker._compare import compare_sinks, compare_sink_metrics
+
+
+class CompareSinksTests(unittest.TestCase):
+
+    def setUp(self):
+        mpm1 = {'Unknown': {'sink1': 0.2829656862745098,
+                            'sink2': 0.2700903353545353,
+                            'sink3': 0.27551818537348455,
+                            'sink4': 0.3444833369795085,
+                            'sink5': 0.35963184240271273,
+                            'sink6': 0.47133120258770073},
+                'source1': {'sink1': 0.281655943627451,
+                            'sink2': 0.17903724786536321,
+                            'sink3': 0.26814235432147049,
+                            'sink4': 0.33563042368555385,
+                            'sink5': 0.14895850153398998,
+                            'sink6': 0.18439678077708035},
+                'source2': {'sink1': 0.28102022058823528,
+                            'sink2': 0.27096481458565358,
+                            'sink3': 0.1712788423934298,
+                            'sink4': 0.17941369503390944,
+                            'sink5': 0.36757629581785889,
+                            'sink6': 0.17007971042396705},
+                'source3': {'sink1': 0.15435814950980392,
+                            'sink2': 0.27990760219444788,
+                            'sink3': 0.28506061791161519,
+                            'sink4': 0.14047254430102823,
+                            'sink5': 0.1238333602454384,
+                            'sink6': 0.17419230621125187}}
+        self.mpm1 = pd.DataFrame(mpm1)
+
+    def test_compare_sink_metrics(self):
+        self.assertEqual(compare_sink_metrics(),
+                         ['absolute_difference', 'euclidean', 'pearson',
+                          'spearman'])
+
+    def test_unknown_metric(self):
+        with self.assertRaises(KeyError):
+            compare_sinks(self.mpm1, self.mpm1, 'not-a-metric')
+
+    def test_non_overlapping_sinks(self):
+        mpm2 = self.mpm1.copy()
+        mpm2.index = ['sink1', 'sink2', 'sink3', 'sink4', 'sink5', 'sink7']
+        with self.assertRaisesRegex(ValueError, 'Sinks'):
+            compare_sinks(self.mpm1, mpm2, 'spearman')
+
+    def test_non_overlapping_sources(self):
+        mpm2 = self.mpm1.copy()
+        mpm2.columns = ['source1', 'source2', 'source4', 'Unknown']
+        with self.assertRaisesRegex(ValueError, 'Sources'):
+            compare_sinks(self.mpm1, mpm2, 'spearman')
+
+    def test_order_independence_sinks(self):
+        mpm1 = self.mpm1.sort_index(ascending=False)
+        mpm2 = self.mpm1.copy().sort_index(ascending=True)
+        # confirm that the indices are now different
+        self.assertEqual(list(mpm1.index), list(reversed(mpm2.index)))
+
+        observed = compare_sinks(self.mpm1, self.mpm1, 'spearman')
+        expected_ids = ['sink1', 'sink2', 'sink3', 'sink4', 'sink5', 'sink6']
+        expected_values = [(1.0, 0.0), (1.0, 0.0), (1.0, 0.0), (1.0, 0.0),
+                           (1.0, 0.0), (1.0, 0.0)]
+        expected = pd.DataFrame(expected_values, index=expected_ids,
+                                columns=['Spearman rho', 'p'])
+        assert_data_frame_almost_equal(observed, expected)
+
+    def test_order_independence_sources(self):
+        mpm1 = self.mpm1.sort_index(ascending=False, axis=1)
+        mpm2 = self.mpm1.copy().sort_index(ascending=True, axis=1)
+        # confirm that the columns are now different
+        self.assertEqual(list(mpm1.columns), list(reversed(mpm2.columns)))
+
+        observed = compare_sinks(self.mpm1, self.mpm1, 'spearman')
+        expected_ids = ['sink1', 'sink2', 'sink3', 'sink4', 'sink5', 'sink6']
+        expected_values = [(1.0, 0.0), (1.0, 0.0), (1.0, 0.0), (1.0, 0.0),
+                           (1.0, 0.0), (1.0, 0.0)]
+        expected = pd.DataFrame(expected_values, index=expected_ids,
+                                columns=['Spearman rho', 'p'])
+        assert_data_frame_almost_equal(observed, expected)
+
+    def test_spearman_perfect(self):
+        observed = compare_sinks(self.mpm1, self.mpm1, 'spearman')
+        expected_ids = ['sink1', 'sink2', 'sink3', 'sink4', 'sink5', 'sink6']
+        expected_values = [(1.0, 0.0), (1.0, 0.0), (1.0, 0.0), (1.0, 0.0),
+                           (1.0, 0.0), (1.0, 0.0)]
+        expected = pd.DataFrame(expected_values, index=expected_ids,
+                                columns=['Spearman rho', 'p'])
+        assert_data_frame_almost_equal(observed, expected)
+
+    def test_spearman(self):
+        mpm1 = {'Unknown': {'sink1': 0.25},
+                'Source1': {'sink1': 0.50},
+                'Source2': {'sink1': 0.25}}
+        mpm1 = pd.DataFrame(mpm1)
+        mpm2 = {'Unknown': {'sink1': 0.1},
+                'Source1': {'sink1': 0.1},
+                'Source2': {'sink1': 0.8}}
+        mpm2 = pd.DataFrame(mpm2)
+
+        observed = compare_sinks(mpm1, mpm2, 'spearman')
+        expected_ids = ['sink1']
+        # expected values computed by calling scipy.stats.spearmanr directly
+        expected_values = [(-0.5, 2./3)]
+        expected = pd.DataFrame(expected_values, index=expected_ids,
+                                columns=['Spearman rho', 'p'])
+        assert_data_frame_almost_equal(observed, expected)
+
+    def test_pearson_perfect(self):
+        observed = compare_sinks(self.mpm1, self.mpm1, 'pearson')
+        expected_ids = ['sink1', 'sink2', 'sink3', 'sink4', 'sink5', 'sink6']
+        expected_values = [(1.0, 0.0), (1.0, 0.0), (1.0, 0.0), (1.0, 0.0),
+                           (1.0, 0.0), (1.0, 0.0)]
+        expected = pd.DataFrame(expected_values, index=expected_ids,
+                                columns=['Pearson r', 'p'])
+        assert_data_frame_almost_equal(observed, expected)
+
+    def test_pearsonr(self):
+        mpm1 = {'Unknown': {'sink1': 0.25},
+                'Source1': {'sink1': 0.50},
+                'Source2': {'sink1': 0.25}}
+        mpm1 = pd.DataFrame(mpm1)
+        mpm2 = {'Unknown': {'sink1': 0.1},
+                'Source1': {'sink1': 0.1},
+                'Source2': {'sink1': 0.8}}
+        mpm2 = pd.DataFrame(mpm2)
+
+        observed = compare_sinks(mpm1, mpm2, 'pearson')
+        expected_ids = ['sink1']
+        # expected values computed by calling scipy.stats.pearsonr directly
+        expected_values = [(-0.5, 2./3)]
+        expected = pd.DataFrame(expected_values, index=expected_ids,
+                                columns=['Pearson r', 'p'])
+        assert_data_frame_almost_equal(observed, expected)
+
+    def test_euclidean_perfect(self):
+        observed = compare_sinks(self.mpm1, self.mpm1, 'euclidean')
+        expected_ids = ['sink1', 'sink2', 'sink3', 'sink4', 'sink5', 'sink6']
+        expected_values = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        expected = pd.DataFrame(expected_values, index=expected_ids,
+                                columns=['Euclidean distance'])
+        assert_data_frame_almost_equal(observed, expected)
+
+    def test_euclidean(self):
+        mpm1 = {'Unknown': {'sink1': 0.25},
+                'Source1': {'sink1': 0.50},
+                'Source2': {'sink1': 0.25}}
+        mpm1 = pd.DataFrame(mpm1)
+        mpm2 = {'Unknown': {'sink1': 0.1},
+                'Source1': {'sink1': 0.1},
+                'Source2': {'sink1': 0.8}}
+        mpm2 = pd.DataFrame(mpm2)
+
+        observed = compare_sinks(mpm1, mpm2, 'euclidean')
+        expected_ids = ['sink1']
+        # expected values computed by calling
+        # scipy.stats.spatial.distance.euclidean directly
+        expected_values = [0.6964194]
+        expected = pd.DataFrame(expected_values, index=expected_ids,
+                                columns=['Euclidean distance'])
+        assert_data_frame_almost_equal(observed, expected)
+
+    def test_absolute_difference(self):
+        mpm1 = {'Unknown': {'sink1': 0.25},
+                'Source1': {'sink1': 0.50},
+                'Source2': {'sink1': 0.25}}
+        mpm1 = pd.DataFrame(mpm1)
+        mpm2 = {'Unknown': {'sink1': 0.1},
+                'Source2': {'sink1': 0.8},
+                'Source1': {'sink1': 0.1}}
+        mpm2 = pd.DataFrame(mpm2)
+
+        observed = compare_sinks(mpm1, mpm2, 'absolute_difference')
+        expected_ids = ['sink1']
+        # expected values computed by hand
+        expected_values = [(0.4, 0.55, 0.15)]
+        expected = pd.DataFrame(expected_values, index=expected_ids,
+                                columns=['Source1', 'Source2', 'Unknown'])
+        assert_data_frame_almost_equal(observed, expected)


### PR DESCRIPTION
This partially addresses #57 and #31.  

@wdwvt1, @johnchase, @lkursell this is an API to compare sourcetracker results. This could be used for the current benchmark and optimization projects as a way to determine how similar a pair of sourcetracker results are. I'm looking for input on the API before I spend too much time more time on it. 

This defines two functions ``compare_sinks`` and ``compare_sink_metrics`` that become part of the public API as of the merge of this pull request (we'll commit to alpha-level stability of these in the next release - we're free to change these until then). 

``compare_sinks`` would take two ``pd.DataFrame`` objects containing observed and expected mixing proportions and a metric to use for comparing the mixing proportions. It would return a ``pd.DataFrame`` containing metric-specific data on the similarity/difference of the mixing proportions. 

``compare_sink_metrics`` is a simple helper function that returns a list of the available metrics. This would be necessary for a QIIME 2 plugin, so interfaces can determine what the available choices are for the ``metric`` parameter of ``compare_sinks``. 