### PR TITLE
Alternative mixing proportions algorithm

### DIFF
--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -1024,3 +1024,67 @@ def plot_heatmap(mpm, cm=plt.cm.viridis, xlabel='Sources', ylabel='Sinks',
     ax.set_ylabel(ylabel)
     ax.set_title(title)
     return fig, ax
+
+################################################################################
+# Alternative Mixing Proportion Methods
+################################################################################
+def method5(sources, sinks):
+    '''
+    Calculates percent probability of each source contributing to the sink 
+    based solely on likelihood of seeing a given feature in a given source 
+    environment.
+    
+    Parameters
+    ----------
+    sources : pd.DataFrame
+        DataFrame of sources x features (rows x columns)
+    sinks : pd.DataFrame
+        DataFrame of sinks x features (rows x columns)
+        
+    Returns
+    -------
+    results : pd.DataFrame
+        Dataframe of sinks x sources (rows x columns) of the contribution of 
+        each source to each sink
+        
+    Examples:
+    ---------
+    # Method5 works by assigning each sink's sequence counts to a source
+    # based solely on the probability of seeing that feature in a source.
+    # source table is source x features (rows x columns)
+    sources = [[1, 2, 3, 4],
+               [4, 2, 1, 3]]
+    sinks =    [3, 3, 3, 1]
+    
+    # Calculate probability of seeing each feature in a source by dividing
+    # each source count by the total sum of that source
+    sources_scaled = [[0.1, 0.2, 0.3, 0.4],
+                      [0.4, 0.2, 0.1, 0.3]]
+    
+    # Multiple the sink's sequence counts by the sources_scaled probability
+    sources_scaled_counts = [[0.3, 0.6, 0.9, 0.4],
+                             [1.2, 0.6, 0.3, 0.3]]
+    
+    # sum up the total sequence contributions across all sources, and then 
+    # recalculate how much sequence contribution each source provided
+    source_contributions = [0.478261, 0.512739]
+    '''
+    
+    # Calculate probability of seeing each feature in a given sources
+    sources_scaled = sources.div(sources.sum(axis=1), axis=0)
+    
+    # Create results container
+    results = pd.DataFrame(np.zeros((len(sources.index), len(sinks.index))),
+                                  index=[sinks.index], columns=[sources.index])
+    
+    for sink in sinks.iterrows():
+        
+        # Multiply sinks counts by prob of seeing that feature in each source
+        sources_scaled_counts = sources_scaled * sink[1].values
+        
+        # Add up a sources seq count contributions, and rescale
+        table_sum = sources_scaled_counts.sum().sum()
+        source_contributions = sources_scaled_counts.sum(axis=1) / table_sum
+        results.loc[sink[0]] = source_contributions
+    
+    return results

--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -482,7 +482,6 @@ def gibbs_sampler(sink, cp, restarts, draws_per_restart, burnin, delay):
     # Basic bookkeeping information we will use throughout the function.
     num_sources = cp.V
     num_features = cp.tau
-    source_indices = np.arange(num_sources)
     sink = sink.astype(np.int32)
     sink_sum = sink.sum()
 
@@ -558,15 +557,17 @@ def gibbs_sampler(sink, cp, restarts, draws_per_restart, burnin, delay):
                     unknown_sum -= 1
 
                 # Calculate the new joint probability vector based on the
-                # removal of the ith sequence. Scale this probability vector
-                # for use by np.random.choice.
+                # removal of the ith sequence.
                 jp = cp.calculate_cp_slice(t, unknown_vector[t], unknown_sum,
                                            envcounts)
 
                 # Reassign the sequence to a new source environment and
                 # update counts for each environment and the unknown source
                 # if necessary.
-                new_e_idx = np.random.choice(source_indices, p=jp / jp.sum())
+                # Note: np.random.choice is ~4x slower than the current cumsum,
+                # searchsorted, and uniform calls.
+                cs = (jp / jp.sum()).cumsum()
+                new_e_idx = np.searchsorted(cs, np.random.uniform(0, 1))
 
                 seq_env_assignments[seq_index] = new_e_idx
                 envcounts[new_e_idx] += 1

--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -557,17 +557,25 @@ def gibbs_sampler(sink, cp, restarts, draws_per_restart, burnin, delay):
                     unknown_sum -= 1
 
                 # Calculate the new joint probability vector based on the
-                # removal of the ith sequence.
+                # removal of the ith sequence. Reassign the sequence to a new
+                # source environment and update counts for each environment and
+                # the unknown source if necessary.
+                # This is the fastest way I've currently found to draw from
+                # `jp`. By stacking (cumsum) the probability of `jp`, we can
+                # draw x from uniform variable in [0, total sum), and then find
+                # which interval that value lies in with searchsorted. Visual
+                # representation below
+                #          e1    e2  e3 e4  e5     unk
+                # jp:    |     |    |  |  |    |          |
+                # x:                          x
+                # new_e_idx == 4 (zero indexed)
+                # This is in contrast to the more intuitive, but much slower
+                # call it replaced:
+                # np.random.choice(num_sources, jp/jp.sum())
                 jp = cp.calculate_cp_slice(t, unknown_vector[t], unknown_sum,
                                            envcounts)
-
-                # Reassign the sequence to a new source environment and
-                # update counts for each environment and the unknown source
-                # if necessary.
-                # Note: np.random.choice is ~4x slower than the current cumsum,
-                # searchsorted, and uniform calls.
-                cs = (jp / jp.sum()).cumsum()
-                new_e_idx = np.searchsorted(cs, np.random.uniform(0, 1))
+                cs = jp.cumsum()
+                new_e_idx = np.searchsorted(cs, np.random.uniform(0, cs[-1]))
 
                 seq_env_assignments[seq_index] = new_e_idx
                 envcounts[new_e_idx] += 1

--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -1025,28 +1025,30 @@ def plot_heatmap(mpm, cm=plt.cm.viridis, xlabel='Sources', ylabel='Sinks',
     ax.set_title(title)
     return fig, ax
 
-################################################################################
+###############################################################################
 # Alternative Mixing Proportion Methods
-################################################################################
+###############################################################################
+
+
 def method5(sources, sinks):
     '''
-    Calculates percent probability of each source contributing to the sink 
-    based solely on likelihood of seeing a given feature in a given source 
+    Calculates percent probability of each source contributing to the sink
+    based solely on likelihood of seeing a given feature in a given source
     environment.
-    
+
     Parameters
     ----------
     sources : pd.DataFrame
         DataFrame of sources x features (rows x columns)
     sinks : pd.DataFrame
         DataFrame of sinks x features (rows x columns)
-        
+
     Returns
     -------
     results : pd.DataFrame
-        Dataframe of sinks x sources (rows x columns) of the contribution of 
+        Dataframe of sinks x sources (rows x columns) of the contribution of
         each source to each sink
-        
+
     Examples:
     ---------
     # Method5 works by assigning each sink's sequence counts to a source
@@ -1055,38 +1057,38 @@ def method5(sources, sinks):
     sources = [[1, 2, 3, 4],
                [4, 2, 1, 3]]
     sinks =    [3, 3, 3, 1]
-    
+
     # Calculate probability of seeing each feature in a source by dividing
     # each source count by the total sum of that source
     sources_scaled = [[0.1, 0.2, 0.3, 0.4],
                       [0.4, 0.2, 0.1, 0.3]]
-    
+
     # Multiple the sink's sequence counts by the sources_scaled probability
     sources_scaled_counts = [[0.3, 0.6, 0.9, 0.4],
                              [1.2, 0.6, 0.3, 0.3]]
-    
-    # sum up the total sequence contributions across all sources, and then 
+
+    # sum up the total sequence contributions across all sources, and then
     # recalculate how much sequence contribution each source provided
     source_contributions = [0.478261, 0.512739]
     '''
     # check input DataFrames
     sources_ok, sinks_ok = validate_gibbs_input(sources, sinks)
-    
+
     # Calculate probability of seeing each feature in a given sources
     sources_scaled = sources_ok.div(sources.sum(axis=1), axis=0)
-    
+
     # Create results container
     results = pd.DataFrame(np.zeros((len(sources.index), len(sinks.index))),
-                                  index=[sinks.index], columns=[sources.index])
-    
+                           index=[sinks.index], columns=[sources.index])
+
     for sink in sinks_ok.iterrows():
-        
+
         # Multiply sinks counts by prob of seeing that feature in each source
         sources_scaled_counts = sources_scaled * sink[1].values
-        
+
         # Add up a sources seq count contributions, and rescale
         table_sum = sources_scaled_counts.sum().sum()
         source_contributions = sources_scaled_counts.sum(axis=1) / table_sum
         results.loc[sink[0]] = source_contributions
-    
+
     return results

--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -1069,15 +1069,17 @@ def method5(sources, sinks):
     # recalculate how much sequence contribution each source provided
     source_contributions = [0.478261, 0.512739]
     '''
+    # check input DataFrames
+    sources_ok, sinks_ok = validate_gibbs_input(sources, sinks)
     
     # Calculate probability of seeing each feature in a given sources
-    sources_scaled = sources.div(sources.sum(axis=1), axis=0)
+    sources_scaled = sources_ok.div(sources.sum(axis=1), axis=0)
     
     # Create results container
     results = pd.DataFrame(np.zeros((len(sources.index), len(sinks.index))),
                                   index=[sinks.index], columns=[sources.index])
     
-    for sink in sinks.iterrows():
+    for sink in sinks_ok.iterrows():
         
         # Multiply sinks counts by prob of seeing that feature in each source
         sources_scaled_counts = sources_scaled * sink[1].values

--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -1031,10 +1031,27 @@ def plot_heatmap(mpm, cm=plt.cm.viridis, xlabel='Sources', ylabel='Sinks',
 
 
 def method5(sources, sinks):
-    '''
+    '''Returns mixing proportions using only feature in source probability
+
+    Summary
+    -------
     Calculates percent probability of each source contributing to the sink
     based solely on likelihood of seeing a given feature in a given source
-    environment.
+    environment. Unlike gibbs(), no Unknown source environemnt is created.
+
+    Notes
+    -----
+    Input validation is done on the sources and sinks. They must
+    be dataframes with integerial data and their columns must match exactly.
+
+    Warnings
+    --------
+    This function does _not_ perform rarefaction, the user should perform
+    rarefaction prior to calling this function.
+
+    This function does not collapse sources or sinks, it expects each row of
+    the `sources` dataframe to represent a unique source, and each row of the
+    `sinks` dataframe to represent a unique sink.
 
     Parameters
     ----------
@@ -1054,9 +1071,11 @@ def method5(sources, sinks):
     # Method5 works by assigning each sink's sequence counts to a source
     # based solely on the probability of seeing that feature in a source.
     # source table is source x features (rows x columns)
-    sources = [[1, 2, 3, 4],
-               [4, 2, 1, 3]]
-    sinks =    [3, 3, 3, 1]
+    sources = pd.DataFrame([[1, 2, 3, 4], [4, 2, 1, 3]],
+                           index=['source1', 'source2'],
+                           columns=['f1', 'f2', 'f3', 'f4'])
+    sinks = pd.DataFrame([[3, 3, 3, 1]], index=['sink1'],
+                         columns=['f1', 'f2', 'f3', 'f4'])
 
     # Calculate probability of seeing each feature in a source by dividing
     # each source count by the total sum of that source
@@ -1074,21 +1093,21 @@ def method5(sources, sinks):
     # check input DataFrames
     sources_ok, sinks_ok = validate_gibbs_input(sources, sinks)
 
-    # Calculate probability of seeing each feature in a given sources
-    sources_scaled = sources_ok.div(sources.sum(axis=1), axis=0)
+    # Calculate probability of seeing each feature in a given source
+    sources_scaled = sources_ok.div(sources_ok.sum(axis=1), axis=0)
 
     # Create results container
-    results = pd.DataFrame(np.zeros((len(sources.index), len(sinks.index))),
-                           index=[sinks.index], columns=[sources.index])
+    results = pd.DataFrame(np.zeros((len(sinks_ok.index),
+                                     len(sources_ok.index))),
+                           index=sinks_ok.index, columns=sources_ok.index)
 
-    for sink in sinks_ok.iterrows():
+    for sink_id, sink_values in sinks_ok.iterrows():
 
         # Multiply sinks counts by prob of seeing that feature in each source
-        sources_scaled_counts = sources_scaled * sink[1].values
+        sources_scaled_counts = sources_scaled * sink_values
 
         # Add up a sources seq count contributions, and rescale
-        table_sum = sources_scaled_counts.sum().sum()
-        source_contributions = sources_scaled_counts.sum(axis=1) / table_sum
-        results.loc[sink[0]] = source_contributions
+        table_sum = sources_scaled_counts.values.sum()
+        results.loc[sink_id] = sources_scaled_counts.sum(axis=1) / table_sum
 
     return results

--- a/sourcetracker/tests/test_sourcetracker.py
+++ b/sourcetracker/tests/test_sourcetracker.py
@@ -1244,21 +1244,23 @@ class PlotHeatmapTests(TestCase):
                                xlabel='Other 1', ylabel='Other 2',
                                title='Other 3')
 
+
 class Method5Tests(TestCase):
+    '''Unit tests for method5'''
 
     def test_method5(self):
         sources = pd.DataFrame([[1, 2, 3, 4], [4, 2, 1, 3]],
-                                index=['source1', 'source2'],
-                                columns=['f1', 'f2', 'f3', 'f4'])
+                               index=['source1', 'source2'],
+                               columns=['f1', 'f2', 'f3', 'f4'])
         sinks = pd.DataFrame([[3, 3, 3, 1], [5, 0, 0, 5]],
-                              index=['sink1', 'sink2'],
-                              columns=['f1', 'f2', 'f3', 'f4'])
+                             index=['sink1', 'sink2'],
+                             columns=['f1', 'f2', 'f3', 'f4'])
 
         obs_result = method5(sources, sinks)
-        exp_result = pd.DataFrame([[ 0.47826087,  0.52173913],
-                                   [ 0.41666667,  0.58333333]],
-                                   index=['sink1', 'sink2'],
-                                   columns=['source1', 'source2'])
+        exp_result = pd.DataFrame([[0.47826087, 0.52173913],
+                                  [0.41666667, 0.58333333]],
+                                  index=['sink1', 'sink2'],
+                                  columns=['source1', 'source2'])
 
         pd.util.testing.assert_frame_equal(obs_result, exp_result)
 

--- a/sourcetracker/tests/test_sourcetracker.py
+++ b/sourcetracker/tests/test_sourcetracker.py
@@ -26,7 +26,8 @@ from sourcetracker._sourcetracker import (intersect_and_sort_samples,
                                           single_sink_feature_table,
                                           ConditionalProbability,
                                           gibbs_sampler, gibbs,
-                                          plot_heatmap)
+                                          plot_heatmap,
+                                          method5)
 
 
 class TestValidateGibbsInput(TestCase):
@@ -1242,6 +1243,24 @@ class PlotHeatmapTests(TestCase):
         fig, ax = plot_heatmap(self.mpm, cm=plt.cm.jet,
                                xlabel='Other 1', ylabel='Other 2',
                                title='Other 3')
+
+class Method5Tests(TestCase):
+
+    def test_method5(self):
+        sources = pd.DataFrame([[1, 2, 3, 4], [4, 2, 1, 3]],
+                                index=['source1', 'source2'],
+                                columns=['f1', 'f2', 'f3', 'f4'])
+        sinks = pd.DataFrame([[3, 3, 3, 1], [5, 0, 0, 5]],
+                              index=['sink1', 'sink2'],
+                              columns=['f1', 'f2', 'f3', 'f4'])
+
+        obs_result = method5(sources, sinks)
+        exp_result = pd.DataFrame([[ 0.47826087,  0.52173913],
+                                   [ 0.41666667,  0.58333333]],
+                                   index=['sink1', 'sink2'],
+                                   columns=['source1', 'source2'])
+
+        pd.util.testing.assert_frame_equal(obs_result, exp_result)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR introduces `method5`, which calculates the percent contributions of sequences to a sink using only the probability of seeing a feature the source. This method does not create an `Unknown` source and does not use the `gibbs` sampling approach. This method is only exposed via a private API, and can be used for testing sourcetracker scripts without waiting on the longer `gibbs` call to run.

@gregcaporaso @wdwvt1 we need a more appropriate and descriptive name for this method, and I'm open for suggestions. I'll email Dan as well to get his naming input.
