### PR TITLE
MAINT: Makes compatible with latest pandas

### DIFF
--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -231,8 +231,9 @@ def subsample_dataframe(df, depth, replace=False):
     pd.DataFrame
         Subsampled dataframe.
     '''
-    f = partial(subsample_counts, n=depth, replace=replace)
-    return df.apply(f, axis=1, reduce=False, raw=False)
+    def subsample(x):
+        return pd.Series(subsample_counts(x.values, depth), index=x.index)
+    return df.apply(subsample, axis=1)
 
 
 def generate_environment_assignments(n, num_sources):


### PR DESCRIPTION
Fixes #111 Pandas changed the `reduce` functionality in `df.apply`
http://pandas.pydata.org/pandas-docs/stable/whatsnew.html?highlight=rolling_mean#changes-to-make-output-of-dataframe-apply-consistent
the new api is backwards incompatible with >0.23.4. The changes in this
pull request work with both versions of pandas. There may be a better
way to achieve this, though I think either way it is preferable to keep
sourcetracker compatible with the recent versions of pandas