### PR TITLE
PERF: Rely on BIOM for upstream data manipulation

### DIFF
--- a/sourcetracker/_cli/gibbs.py
+++ b/sourcetracker/_cli/gibbs.py
@@ -17,7 +17,7 @@ from biom import Table, load_table
 from sourcetracker._cli import cli
 from sourcetracker._gibbs import gibbs_helper
 from sourcetracker._plot import plot_heatmap
-from sourcetracker._util import parse_sample_metadata, biom_to_df
+from sourcetracker._util import parse_sample_metadata
 
 # import default descriptions
 from sourcetracker._gibbs_defaults import (DESC_TBL, DESC_MAP, DESC_OUT,
@@ -145,7 +145,7 @@ def gibbs(table_fp: Table,
 
     # Load the metadata file and feature table.
     sample_metadata = parse_sample_metadata(open(mapping_fp, 'U'))
-    feature_table = biom_to_df(load_table(table_fp))
+    feature_table = load_table(table_fp)
 
     # run the gibbs sampler helper function (same used for q2)
     results = gibbs_helper(feature_table, sample_metadata, loo, jobs,

--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -129,7 +129,6 @@ def intersect_and_sort_samples(sample_metadata, feature_table):
         s_metadata = sample_metadata.loc[shared_samples].copy()
         s_features = feature_table.filter(set(shared_samples),
                                           inplace=False)
-        s_features = s_features.remove_empty()
         s_features = s_features.sort_order(shared_samples)
     return s_metadata, s_features
 
@@ -208,7 +207,7 @@ def collapse_source_data(sample_metadata, feature_table, source_samples,
     sources = sample_metadata.loc[source_samples, :]
     overlap = set(sources.index) & set(feature_table.ids())
     table = feature_table.filter(overlap,
-                                 inplace=False).remove_empty()
+                                 inplace=False)
     collapse_mapping = sources[category].to_dict()
     def collapse_f(i, m):
         return collapse_mapping[i]

--- a/sourcetracker/_sourcetracker.py
+++ b/sourcetracker/_sourcetracker.py
@@ -18,25 +18,23 @@ from skbio.stats import subsample_counts
 
 
 def validate_gibbs_input(sources, sinks=None):
-    '''Validate `gibbs` inputs and coerce/round to type `np.int32`.
+    '''Validate `gibbs` inputs.
 
     Summary
     -------
-    Checks if data contains `nan` or `null` values, and returns data as
-    type `np.int32`. If both `sources` and `sinks` are passed, columns must
-    match exactly (including order).
+    Checks if data contains `nan` or `null` values. If both `sources` and
+    `sinks` are passed, columns must match exactly (including order).
 
     Parameters
     ----------
-    sources : pd.DataFrame
-        A dataframe containing count data. Must be castable to `np.int32`.
-    sinks : optional, pd.DataFrame or None
-        If not `None` a dataframe containing count data that is castable to
-        `np.int32`.
+    sources : biom.Table
+        A Table containing count data.
+    sinks : optional, biom.Table or None
+        If not `None` a Table containing count data
 
     Returns
     -------
-    pd.Dataframe(s)
+    biom.Table
 
     Raises
     ------
@@ -50,35 +48,32 @@ def validate_gibbs_input(sources, sinks=None):
         If `sources` and `sinks` passed and columns are not identical.
     '''
     if sinks is not None:
-        dfs = [sources, sinks]
+        tabs = [sources, sinks]
     else:
-        dfs = [sources]
+        tabs = [sources]
 
-    for df in dfs:
-        # Because of this bug (https://github.com/numpy/numpy/issues/6114)
-        # we can't use e.g. np.isreal(df.dtypes).all(). Instead we use
-        # applymap. Based on:
-        # http://stackoverflow.com/questions/21771133/finding-non-numeric-rows-in-dataframe-in-pandas
-        if not df.applymap(np.isreal).values.all():
-            raise ValueError('A dataframe contains one or more values which '
-                             'are not numeric. Data must be exclusively '
-                             'positive integers.')
-        if np.isnan(df.values).any():
-            raise ValueError('A dataframe has `nan` or `null` values. Data '
-                             'must be exclusively positive integers.')
-        if (df.values < 0).any():
+    for tab in tabs:
+        if (tab.matrix_data.data < 0).any():
             raise ValueError('A dataframe has a negative count. Data '
                              'must be exclusively positive integers.')
+        if np.isnan(tab.matrix_data.data).any():
+            raise ValueError("A table must not have nan values")
 
     if sinks is not None:
-        if not (sinks.columns == sources.columns).all():
+        if len(sinks.ids(axis='observation')) != len(sources.ids(axis='observation')):  # noqa
             raise ValueError('Dataframes do not contain identical (and '
                              'identically ordered) columns. Columns must '
                              'match exactly.')
-        return (sources.astype(np.int32, copy=False),
-                sinks.astype(np.int32, copy=False))
+        elif (sinks.ids(axis='observation') != sources.ids(axis='observation')).any():  # noqa
+            raise ValueError('Dataframes do not contain identical (and '
+                             'identically ordered) columns. Columns must '
+                             'match exactly.')
+
+        # n.b. not casting to int32 as we cast to float64 later, and separately
+        # to int32, so deferring the casting
+        return sources, sinks
     else:
-        return sources.astype(np.int32, copy=False)
+        return sources
 
 
 def validate_gibbs_parameters(alpha1, alpha2, beta, restarts,
@@ -107,7 +102,7 @@ def intersect_and_sort_samples(sample_metadata, feature_table):
     ----------
     sample_metadata : pd.DataFrame
         Contingency table with rows, columns = samples, metadata.
-    feature_table : pd.DataFrame
+    feature_table : biom.Table
         Contingency table with rows, columns = samples, features.
 
     Returns
@@ -120,21 +115,23 @@ def intersect_and_sort_samples(sample_metadata, feature_table):
     ValueError
         If no shared samples are found.
     '''
-    shared_samples = np.intersect1d(sample_metadata.index, feature_table.index)
+    shared_samples = np.array(sorted(set(sample_metadata.index) &
+                                     set(feature_table.ids())))
     if shared_samples.size == 0:
         raise ValueError('There are no shared samples between the feature '
                          'table and the sample metadata. Ensure that you have '
                          'passed the correct files.')
-    elif (shared_samples.size == sample_metadata.shape[0] ==
-          feature_table.shape[0]):
+
+    elif (shared_samples.size == sample_metadata.shape[0] == feature_table.shape[1]):
         s_metadata = sample_metadata.copy()
-        s_features = feature_table.copy()
+        s_features = feature_table.sort_order(list(s_metadata.index))
     else:
-        s_metadata = sample_metadata.loc[np.in1d(sample_metadata.index,
-                                                 shared_samples), :].copy()
-        s_features = feature_table.loc[np.in1d(feature_table.index,
-                                               shared_samples), :].copy()
-    return s_metadata, s_features.loc[s_metadata.index, :]
+        s_metadata = sample_metadata.loc[shared_samples].copy()
+        s_features = feature_table.filter(set(shared_samples),
+                                          inplace=False)
+        s_features = s_features.remove_empty()
+        s_features = s_features.sort_order(shared_samples)
+    return s_metadata, s_features
 
 
 def get_samples(sample_metadata, col, value):
@@ -143,22 +140,21 @@ def get_samples(sample_metadata, col, value):
 
 
 def collapse_source_data(sample_metadata, feature_table, source_samples,
-                         category, method):
+                         category, method='mean'):
     '''Collapse each set of source samples into an aggregate source.
 
     Parameters
     ----------
     sample_metadata : pd.DataFrame
         Contingency table where rows are features and columns are metadata.
-    feature_table : pd.DataFrame
+    feature_table : biom.Table
         Contingency table where rows are features and columns are samples.
     source_samples : iterable
         Samples which should be considered for collapsing (i.e. are sources).
     category : str
         Column in `sample_metadata` which should be used to group samples.
-    method : str
-        One of the available aggregation methods in pd.DataFrame.agg (mean,
-        median, prod, sum, std, var).
+    methon : str
+        Either 'mean' or 'sum'
 
     Returns
     -------
@@ -210,33 +206,21 @@ def collapse_source_data(sample_metadata, feature_table, source_samples,
     3.0           10  75  20  75
     '''
     sources = sample_metadata.loc[source_samples, :]
-    table = feature_table.loc[sources.index, :].copy()
-    table['collapse_col'] = sources[category]
-    return validate_gibbs_input(table.groupby('collapse_col').agg(method))
+    overlap = set(sources.index) & set(feature_table.ids())
+    table = feature_table.filter(overlap,
+                                 inplace=False).remove_empty()
+    collapse_mapping = sources[category].to_dict()
+    def collapse_f(i, m):
+        return collapse_mapping[i]
 
-
-def subsample_dataframe(df, depth, replace=False):
-    '''Subsample (rarify) input dataframe without replacement.
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        Feature table where rows are features and columns are samples.
-    depth : int
-        Number of sequences to choose per sample.
-    replace : bool, optional
-        If ``True``, subsample with replacement. If ``False`` (the default),
-        subsample without replacement.
-
-    Returns
-    -------
-    pd.DataFrame
-        Subsampled dataframe.
-    '''
-    def subsample(x):
-        return pd.Series(subsample_counts(x.values, n=depth, replace=replace),
-                         index=x.index)
-    return df.apply(subsample, axis=1)
+    if method == 'sum':
+        table = table.collapse(collapse_f, norm=False)
+    else:
+        table = table.collapse(collapse_f, norm=True)
+    table = table.sort_order(sorted(table.ids()))
+    table.del_metadata()
+    table.matrix_data.data = np.floor(table.matrix_data.data)
+    return validate_gibbs_input(table)
 
 
 def generate_environment_assignments(n, num_sources):
@@ -370,9 +354,8 @@ class ConditionalProbability(object):
         self.alpha1 = alpha1
         self.alpha2 = alpha2
         self.beta = beta
-        self.m_xivs = source_data.astype(np.float64)
-        self.m_vs = np.expand_dims(source_data.sum(1),
-                                   axis=1).astype(np.float64)
+        self.m_xivs = np.array(source_data.toarray())
+        self.m_vs = source_data.sum(1).astype(np.float64)
         self.V = source_data.shape[0] + 1
         self.tau = source_data.shape[1]
         # Create the joint probability vector which will be overwritten each
@@ -390,14 +373,8 @@ class ConditionalProbability(object):
                           (self.m_vs + self.tau * self.alpha1)
         self.denominator_p_v = self.n - 1 + (self.beta * self.V)
 
-        # We are going to be accessing columns of this array in the innermost
-        # loop of the Gibbs sampler. By forcing this array into 'F' order -
-        # 'Fortran-contiguous' - we've set it so that accessing column slices
-        # is faster. Tests indicate about 2X speed up in this operation from
-        # 'F' order as opposed to the default 'C' order.
         self.known_source_cp = np.array(self.known_p_tv / self.denominator_p_v,
-                                        order='F', dtype=np.float64)
-
+                                        dtype=np.float64, order='F')
         self.alpha2_n = self.alpha2 * self.n
         self.alpha2_n_tau = self.alpha2_n * self.tau
 
@@ -440,7 +417,7 @@ def gibbs_sampler(sink, cp, restarts, draws_per_restart, burnin, delay):
 
     Parameters
     ----------
-    sink : np.array
+    sink : scipy.sparse.csr (or csc) vector
         A one dimentional array containing counts of features whose sources are
         to be estimated.
     cp : ConditionalProbability object
@@ -510,6 +487,8 @@ def gibbs_sampler(sink, cp, restarts, draws_per_restart, burnin, delay):
     # reassigned based on the increasinly accurate distribution. sink[i] i's
     # will be placed in the `taxon_sequence` vector to allow each individual
     # count to be removed and reassigned.
+
+    # indices and data are int32 already from cast
     taxon_sequence = np.repeat(np.arange(num_features), sink).astype(np.int32)
 
     # Update the conditional probability class now that we have the sink sum.
@@ -634,13 +613,11 @@ def gibbs(sources, sinks=None, alpha1=.001, alpha2=.1, beta=10, restarts=10,
 
     Parameters
     ----------
-    sources : DataFrame
-        A dataframe containing source data (rows are sources, columns are
-        features). The index must be the names of the sources.
-    sinks : DataFrame or None
-        A dataframe containing sink data (rows are sinks, columns are
-        features). The index must be the names of the sinks. If `None`,
-        leave-one-out (LOO) prediction will be done.
+    sources : biom.Table
+        A Table containing source data
+    sinks : biom.Table or None
+        A Table containing sink data. If `None`, leave-one-out (LOO) prediction
+        will be done.
     alpha1 : float
         Prior counts of each feature in the training environments. Higher
         values decrease the trust in the training environments, and make
@@ -773,11 +750,13 @@ def gibbs(sources, sinks=None, alpha1=.001, alpha2=.1, beta=10, restarts=10,
     # Run LOO predictions on `sources`.
     if sinks is None:
         cps_and_sinks = []
-        for source in sources.index:
+        for source in sources.ids():
             # fix the deprecated pandas code
-            _sources = sources.loc[sources.index.map(lambda x: x != source)]
-            cp = ConditionalProbability(alpha1, alpha2, beta, _sources.values)
-            sink = sources.loc[source, :].values
+            _sources = sources.filter(set(sources.ids()) - {source, },
+                                      inplace=False)
+            cp = ConditionalProbability(alpha1, alpha2, beta,
+                                        _sources.matrix_data.T)
+            sink = sources.filter({source, }, inplace=False).matrix_data.T.toarray()[0]
             cps_and_sinks.append((cp, sink))
 
         f = partial(_gibbs_loo, **kwargs)
@@ -788,9 +767,10 @@ def gibbs(sources, sinks=None, alpha1=.001, alpha2=.1, beta=10, restarts=10,
 
     # Run normal prediction on `sinks`.
     else:
-        cp = ConditionalProbability(alpha1, alpha2, beta, sources.values)
+        cp = ConditionalProbability(alpha1, alpha2, beta,
+                                    sources.matrix_data.T)
         f = partial(gibbs_sampler, cp=cp, **kwargs)
-        args = sinks.values
+        args = sinks.matrix_data.T.toarray()
         loo = False
 
     with Pool(jobs) as p:
@@ -799,8 +779,8 @@ def gibbs(sources, sinks=None, alpha1=.001, alpha2=.1, beta=10, restarts=10,
     return collate_gibbs_results([i[0] for i in results],
                                  [i[1] for i in results],
                                  [i[2] for i in results],
-                                 sinks.index, sources.index,
-                                 sources.columns,
+                                 sinks.ids(), sources.ids(),
+                                 sources.ids(axis='observation'),
                                  create_feature_tables, loo=loo)
 
 

--- a/sourcetracker/_util.py
+++ b/sourcetracker/_util.py
@@ -30,21 +30,3 @@ def parse_sample_metadata(f):
     sample_metadata.set_index(sample_metadata.columns[0], drop=True,
                               append=False, inplace=True)
     return sample_metadata
-
-
-def biom_to_df(biom_table):
-    '''Turn biom table into dataframe.
-
-    Parameters
-    ----------
-    biom_table : biom.table.Table
-        Biom table.
-
-    Returns
-    -------
-    feature_table : pd.DataFrame
-        Contingency table with rows, columns = samples, features.
-    '''
-    return pd.DataFrame(biom_table._data.toarray().T,
-                        index=biom_table.ids(axis='sample'),
-                        columns=biom_table.ids(axis='observation'))

--- a/sourcetracker/tests/test_sourcetracker.py
+++ b/sourcetracker/tests/test_sourcetracker.py
@@ -13,10 +13,11 @@ from unittest import TestCase, main
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import biom
+from scipy.sparse import csr_matrix
 
 from sourcetracker._sourcetracker import (intersect_and_sort_samples,
                                           collapse_source_data,
-                                          subsample_dataframe,
                                           validate_gibbs_input,
                                           validate_gibbs_parameters,
                                           collate_gibbs_results,
@@ -29,6 +30,9 @@ from sourcetracker._sourcetracker import (intersect_and_sort_samples,
 from sourcetracker._plot import plot_heatmap
 
 
+def dtot(df):
+    return biom.Table(df.values, df.index, df.columns)
+
 class TestValidateGibbsInput(TestCase):
 
     def setUp(self):
@@ -38,138 +42,89 @@ class TestValidateGibbsInput(TestCase):
     def test_no_errors_(self):
         # A table where nothing is wrong, no changes expected.
         data = np.random.randint(0, 10, size=20).reshape(5, 4)
-        sources = pd.DataFrame(data.astype(np.int32), index=self.index,
-                               columns=self.columns)
-        exp_sources = pd.DataFrame(data.astype(np.int32), index=self.index,
-                                   columns=self.columns)
+        sources = dtot(pd.DataFrame(data.astype(np.int32), index=self.index,
+                                    columns=self.columns))
+        exp_sources = dtot(pd.DataFrame(data.astype(np.int32), index=self.index,
+                                        columns=self.columns))
         obs = validate_gibbs_input(sources)
-        pd.util.testing.assert_frame_equal(obs, sources)
+        self.assertEqual(obs, sources)
 
         # Sources and sinks.
-        sinks = pd.DataFrame(data, index=self.index, columns=self.columns)
-        exp_sinks = pd.DataFrame(data.astype(np.int32), index=self.index,
-                                 columns=self.columns)
+        sinks = dtot(pd.DataFrame(data, index=self.index, columns=self.columns))
+        exp_sinks = dtot(pd.DataFrame(data.astype(np.int32), index=self.index,
+                                      columns=self.columns))
         obs_sources, obs_sinks = validate_gibbs_input(sources, sinks)
-        pd.util.testing.assert_frame_equal(obs_sources, exp_sources)
-        pd.util.testing.assert_frame_equal(obs_sinks, exp_sinks)
-
-    def test_float_data(self):
-        # Data is float, expect rounding.
-        data = np.random.uniform(0, 1, size=20).reshape(5, 4)
-        sources = pd.DataFrame(data, index=self.index, columns=self.columns)
-        exp_sources = pd.DataFrame(np.zeros(20).reshape(5, 4).astype(np.int32),
-                                   index=self.index, columns=self.columns)
-        obs_sources = validate_gibbs_input(sources)
-        pd.util.testing.assert_frame_equal(obs_sources, exp_sources)
-
-        data = np.random.uniform(0, 1, size=20).reshape(5, 4) + 1.
-        sources = pd.DataFrame(data, index=self.index, columns=self.columns)
-        exp_sources = pd.DataFrame(np.ones(20).reshape(5, 4).astype(np.int32),
-                                   index=self.index, columns=self.columns)
-        obs_sources = validate_gibbs_input(sources)
-        pd.util.testing.assert_frame_equal(obs_sources, exp_sources)
-
-        # Sources and sinks.
-        data = np.random.uniform(0, 1, size=20).reshape(5, 4) + 5
-        sinks = pd.DataFrame(data,
-                             index=self.index,
-                             columns=self.columns)
-        exp_sinks = \
-            pd.DataFrame(5 * np.ones(20).reshape(5, 4).astype(np.int32),
-                         index=self.index,
-                         columns=self.columns)
-        obs_sources, obs_sinks = validate_gibbs_input(sources, sinks)
-        pd.util.testing.assert_frame_equal(obs_sources, exp_sources)
-        pd.util.testing.assert_frame_equal(obs_sinks, exp_sinks)
+        self.assertEqual(obs_sources, exp_sources)
+        self.assertEqual(obs_sinks, exp_sinks)
 
     def test_negative_data(self):
         # Values less than 0, expect errors.
         data = np.random.uniform(0, 1, size=20).reshape(5, 4) - 1.
-        sources = pd.DataFrame(data,
+        sources = dtot(pd.DataFrame(data,
                                index=self.index,
-                               columns=self.columns)
+                               columns=self.columns))
         self.assertRaises(ValueError, validate_gibbs_input, sources)
 
         data = -1 * np.random.randint(0, 20, size=20).reshape(5, 4)
-        sources = pd.DataFrame(data,
+        sources = dtot(pd.DataFrame(data,
                                index=self.index,
-                               columns=self.columns)
+                               columns=self.columns))
         self.assertRaises(ValueError, validate_gibbs_input, sources)
 
         # Sources and sinks.
         data = np.random.randint(0, 10, size=20).reshape(5, 4) + 1
-        sources = pd.DataFrame(data.astype(np.int32),
+        sources = dtot(pd.DataFrame(data.astype(np.int32),
                                index=self.index,
-                               columns=self.columns)
-        sinks = pd.DataFrame(-10 * data,
+                               columns=self.columns))
+        sinks = dtot(pd.DataFrame(-10 * data,
                              index=self.index,
-                             columns=self.columns)
+                             columns=self.columns))
         self.assertRaises(ValueError, validate_gibbs_input, sources, sinks)
 
     def test_nan_data(self):
         # nans, expect errors.
         data = np.random.uniform(0, 1, size=20).reshape(5, 4)
         data[3, 2] = np.nan
-        sources = pd.DataFrame(data,
+        sources = dtot(pd.DataFrame(data,
                                index=self.index,
-                               columns=self.columns)
+                               columns=self.columns))
         self.assertRaises(ValueError, validate_gibbs_input, sources)
 
         # Sources and sinks.
         data = np.random.randint(0, 10, size=20).reshape(5, 4) + 1.
-        sources = pd.DataFrame(data,
+        sources = dtot(pd.DataFrame(data,
                                index=self.index,
-                               columns=self.columns)
+                               columns=self.columns))
         data[1, 3] = np.nan
-        sinks = pd.DataFrame(data,
+        sinks = dtot(pd.DataFrame(data,
                              index=self.index,
-                             columns=self.columns)
-        self.assertRaises(ValueError, validate_gibbs_input, sources, sinks)
-
-    def test_non_numeric_data(self):
-        # data contains at least some non-numeric columns, expect errors.
-        data = np.random.randint(0, 10, size=20).reshape(5, 4)
-        sources = pd.DataFrame(data.astype(np.int32),
-                               index=self.index,
-                               columns=self.columns)
-        sources.iloc[2, 2] = '3.a'
-        self.assertRaises(ValueError, validate_gibbs_input, sources)
-
-        # Sources and sinks.
-        data = np.random.randint(0, 10, size=20).reshape(5, 4)
-        sources = pd.DataFrame(data.astype(np.int32),
-                               index=self.index,
-                               columns=self.columns)
-        sinks = pd.DataFrame(data.astype(np.int32),
-                             index=self.index,
-                             columns=self.columns)
-        sinks.iloc[2, 2] = '3'
+                             columns=self.columns))
         self.assertRaises(ValueError, validate_gibbs_input, sources, sinks)
 
     def test_columns_identical(self):
         # Columns are identical, no error expected.
         data = np.random.randint(0, 10, size=20).reshape(5, 4)
-        sources = pd.DataFrame(data.astype(np.int32),
+        sources = dtot(pd.DataFrame(data.astype(np.int32),
                                index=self.index,
-                               columns=self.columns)
+                               columns=self.columns).T)
         data = np.random.randint(0, 10, size=200).reshape(50, 4)
-        sinks = pd.DataFrame(data.astype(np.int32),
+        sinks = dtot(pd.DataFrame(data.astype(np.int32),
                              index=['s%s' % i for i in range(50)],
-                             columns=self.columns)
+                             columns=self.columns).T)
         obs_sources, obs_sinks = validate_gibbs_input(sources, sinks)
-        pd.util.testing.assert_frame_equal(obs_sources, sources)
-        pd.util.testing.assert_frame_equal(obs_sinks, sinks)
+        self.assertEqual(obs_sources, sources)
+        self.assertEqual(obs_sinks, sinks)
 
     def test_columns_non_identical(self):
         # Columns are not identical, error expected.
         data = np.random.randint(0, 10, size=20).reshape(5, 4)
-        sources = pd.DataFrame(data.astype(np.int32),
+        sources = dtot(pd.DataFrame(data.astype(np.int32),
                                index=self.index,
-                               columns=self.columns)
+                               columns=self.columns))
         data = np.random.randint(0, 10, size=200).reshape(50, 4)
-        sinks = pd.DataFrame(data.astype(np.int32),
+        sinks = dtot(pd.DataFrame(data.astype(np.int32),
                              index=['s%s' % i for i in range(50)],
-                             columns=['feature%s' % i for i in range(4)])
+                             columns=['feature%s' % i for i in range(4)]))
         self.assertRaises(ValueError, validate_gibbs_input, sources, sinks)
 
 
@@ -233,33 +188,33 @@ class TestIntersectAndSortSamples(TestCase):
         # feature and sample tables. Notice that order is different between
         # the samples that are shared between both tables. The order of samples
         # in the returned tables is set by the ordering done in np.intersect1d.
-        sdata_c1 = [3.1, 'red', 5]
-        sdata_c2 = [3.6, 'yellow', 7]
-        sdata_c3 = [3.9, 'yellow', -2]
-        sdata_c4 = [2.5, 'red', 5]
-        sdata_c5 = [6.7, 'blue', 10]
+        sdata_c1 = [3.1, 5]
+        sdata_c2 = [3.6, 7]
+        sdata_c3 = [3.9, -2]
+        sdata_c4 = [2.5, 5]
+        sdata_c5 = [6.7, 10]
         samples = ['s1', 's4', 's2', 's3', 'sX']
-        headers = ['pH', 'color', 'day']
+        headers = ['pH', 'day']
         stable = pd.DataFrame([sdata_c1, sdata_c4, sdata_c2, sdata_c3,
                                sdata_c5], index=samples, columns=headers)
 
         fdata = np.arange(90).reshape(9, 10)
         samples = ['s%i' % i for i in range(3, 12)]
         columns = ['o%i' % i for i in range(1, 11)]
-        ftable = pd.DataFrame(fdata, index=samples, columns=columns)
+        ftable = dtot(pd.DataFrame(fdata, index=samples, columns=columns).T)
 
-        exp_ftable = pd.DataFrame(fdata[[1, 0], :], index=['s4', 's3'],
-                                  columns=columns)
-        exp_stable = pd.DataFrame([sdata_c4, sdata_c3], index=['s4', 's3'],
+        exp_ftable = dtot(pd.DataFrame(fdata[[1, 0], :], index=['s4', 's3'],
+                                  columns=columns).T)
+        exp_ftable = exp_ftable.sort_order(['s3', 's4'])
+        exp_stable = pd.DataFrame([sdata_c3, sdata_c4], index=['s3', 's4'],
                                   columns=headers)
 
         obs_stable, obs_ftable = intersect_and_sort_samples(stable, ftable)
-
         pd.util.testing.assert_frame_equal(obs_stable, exp_stable)
-        pd.util.testing.assert_frame_equal(obs_ftable, exp_ftable)
+        self.assertEqual(obs_ftable, exp_ftable)
 
         # No shared samples, expect a ValueError.
-        ftable.index = ['ss%i' % i for i in range(9)]
+        ftable.update_ids({i: 'ss%s' % i for i in ftable.ids()}, inplace=True)
         self.assertRaises(ValueError, intersect_and_sort_samples, stable,
                           ftable)
 
@@ -267,14 +222,14 @@ class TestIntersectAndSortSamples(TestCase):
         fdata = np.arange(50).reshape(5, 10)
         samples = ['s1', 's4', 's2', 's3', 'sX']
         columns = ['o%i' % i for i in range(10)]
-        ftable = pd.DataFrame(fdata, index=samples, columns=columns)
+        ftable = dtot(pd.DataFrame(fdata, index=samples, columns=columns).T)
 
-        exp_ftable = ftable.loc[stable.index, :]
+        exp_ftable = ftable.copy()
         exp_stable = stable
 
         obs_stable, obs_ftable = intersect_and_sort_samples(stable, ftable)
         pd.util.testing.assert_frame_equal(obs_stable, exp_stable)
-        pd.util.testing.assert_frame_equal(obs_ftable, exp_ftable)
+        self.assertEqual(obs_ftable, exp_ftable)
 
 
 class TestGetSamples(TestCase):
@@ -321,39 +276,26 @@ class TestCollapseSourceData(TestCase):
                           [0,  25,  10,   5],
                           [0,  25,  10,   5],
                           [100,   0,  10,   5]])
-        ftable = pd.DataFrame(fdata, index=stable.index,
-                              columns=map(str, np.arange(4)))
-        source_samples = ['sample1', 'sample2', 'sample3']
-        method = 'sum'
-        obs = collapse_source_data(stable, ftable, source_samples, category,
-                                   method)
-        exp_data = np.vstack((fdata[1, :], fdata[0, :] + fdata[2, :]))
-        exp_index = [0.4, 3.0]
-        exp = pd.DataFrame(exp_data.astype(np.int32), index=exp_index,
-                           columns=map(str, np.arange(4)))
-        exp.index.name = 'collapse_col'
-        pd.util.testing.assert_frame_equal(obs, exp)
+        ftable = dtot(pd.DataFrame(fdata, index=stable.index,
+                              columns=list('0123')).T)
 
         # Example with collapse mode 'mean'. This will cause non-integer values
         # to be present, which the validate_gibbs_input should catch.
         source_samples = ['sample1', 'sample2', 'sample3', 'sample4']
-        method = 'mean'
-        obs = collapse_source_data(stable, ftable, source_samples, category,
-                                   method)
+        obs = collapse_source_data(stable, ftable, source_samples, category)
         exp_data = np.vstack((fdata[1, :],
                               fdata[[0, 2, 3], :].mean(0))).astype(np.int32)
         exp_index = [0.4, 3.0]
-        exp = pd.DataFrame(exp_data.astype(np.int32), index=exp_index,
-                           columns=map(str, np.arange(4)))
-        exp.index.name = 'collapse_col'
-        pd.util.testing.assert_frame_equal(obs, exp)
+        exp = dtot(pd.DataFrame(exp_data.astype(np.int32), index=exp_index,
+                           columns=map(str, np.arange(4))).T)
+        self.assertEqual(obs, exp)
 
     def test_example2(self):
         # Test on another arbitrary example.
         data = np.arange(200).reshape(20, 10)
         oids = ['o%s' % i for i in range(20)]
         sids = ['s%s' % i for i in range(10)]
-        ftable = pd.DataFrame(data.T, index=sids, columns=oids)
+        ftable = dtot(pd.DataFrame(data.T, index=sids, columns=oids).T)
         _stable = \
             {'s4': {'cat1': '2', 'cat2': 'x', 'cat3': 'A', 'cat4': 'D'},
              's0': {'cat1': '1', 'cat2': 'y', 'cat3': 'z', 'cat4': 'D'},
@@ -378,57 +320,8 @@ class TestCollapseSourceData(TestCase):
                               336,  366, 396, 426, 456, 486, 516, 546, 576]],
                             dtype=np.int32)
 
-        exp = pd.DataFrame(exp_data, index=exp_index, columns=oids)
-        exp.index.name = 'collapse_col'
-        pd.util.testing.assert_frame_equal(obs, exp)
-
-
-class TestSubsampleDataframe(TestCase):
-
-    def test_no_errors_expected(self):
-        # Testing this function deterministically is hard because cython is
-        # generating the PRNG calls. We'll settle for ensuring that the sums
-        # are correct.
-        fdata = np.array([[10,  50,  10,  70],
-                          [0,  25,  10,   5],
-                          [0,  25,  10,   5],
-                          [100,   0,  10,   5]])
-        ftable = pd.DataFrame(fdata, index=['s1', 's2', 's3', 's4'],
-                              columns=map(str, np.arange(4)))
-        n = 30
-        obs = subsample_dataframe(ftable, n)
-        self.assertTrue((obs.sum(axis=1) == n).all())
-
-    def test_subsample_with_replacement(self):
-        # Testing this function deterministically is hard because cython is
-        # generating the PRNG calls. We'll settle for ensuring that the sums
-        # are correct.
-        fdata = np.array([[10,  50,  10,  70],
-                          [0,  25,  10,   5],
-                          [0,  25,  10,   5],
-                          [100,   0,  10,   5]])
-        ftable = pd.DataFrame(fdata, index=['s1', 's2', 's3', 's4'],
-                              columns=map(str, np.arange(4)))
-        n = 30
-        obs = subsample_dataframe(ftable, n, replace=True)
-        self.assertTrue((obs.sum(axis=1) == n).all())
-
-    def test_shape_doesnt_change(self):
-        # Test that when features are removed by subsampling, the shape of the
-        # table does not change. Although rarifaction is stochastic, the
-        # probability that the below table does not lose at least one feature
-        # during rarefaction (and thus satisfy as the test of the condition we)
-        # are interested in) is nearly 0.
-        fdata = np.array([[0,   0,   0, 1e4],
-                          [0,   0,   1, 1e4],
-                          [0,   1,   0, 1e4],
-                          [1,   0,   0, 1e4]]).astype(int)
-        ftable = pd.DataFrame(fdata, index=['s1', 's2', 's3', 's4'],
-                              columns=map(str, np.arange(4)))
-        n = 10
-        obs = subsample_dataframe(ftable, n)
-        self.assertTrue((obs.sum(axis=1) == n).all())
-        self.assertEqual(obs.shape, ftable.shape)
+        exp = dtot(pd.DataFrame(exp_data, index=exp_index, columns=oids).T)
+        self.assertEqual(obs, exp)
 
 
 class TestDataAggregationFunctions(TestCase):
@@ -781,8 +674,8 @@ class ConditionalProbabilityTests(TestCase):
         self.alpha1 = .5
         self.alpha2 = .001
         self.beta = 10
-        self.source_data = np.array([[0, 0, 0, 100, 100, 100],
-                                     [100, 100, 100, 0, 0, 0]])
+        self.source_data = csr_matrix(np.array([[0, 0, 0, 100, 100, 100],
+                                                [100, 100, 100, 0, 0, 0]]))
         self.cp = ConditionalProbability(self.alpha1, self.alpha2, self.beta,
                                          self.source_data)
 
@@ -790,7 +683,7 @@ class ConditionalProbabilityTests(TestCase):
         exp_alpha1 = self.alpha1
         exp_alpha2 = self.alpha2
         exp_beta = self.beta
-        exp_m_xivs = self.source_data
+        exp_m_xivs = self.source_data.toarray()
         exp_m_vs = np.array([[300], [300]])
         exp_V = 3
         exp_tau = 6
@@ -799,7 +692,8 @@ class ConditionalProbabilityTests(TestCase):
         self.assertEqual(self.cp.alpha1, exp_alpha1)
         self.assertEqual(self.cp.alpha2, exp_alpha2)
         self.assertEqual(self.cp.beta, exp_beta)
-        np.testing.assert_array_equal(self.cp.m_xivs, exp_m_xivs)
+        np.testing.assert_array_equal(self.cp.m_xivs,
+                                      exp_m_xivs)
         np.testing.assert_array_equal(self.cp.m_vs, exp_m_vs)
         self.assertEqual(self.cp.V, exp_V)
         self.assertEqual(self.cp.tau, exp_tau)
@@ -814,10 +708,10 @@ class ConditionalProbabilityTests(TestCase):
         alpha1 = .01
         alpha2 = .3
         beta = 35
-        source_data = np.array([[10, 5,  2,  100],
-                                [0,  76, 7,  3],
-                                [9,  5,  0,  0],
-                                [0,  38, 11, 401]])
+        source_data = csr_matrix(np.array([[10, 5,  2,  100],
+                                           [0,  76, 7,  3],
+                                           [9,  5,  0,  0],
+                                           [0,  38, 11, 401]]))
         cp = ConditionalProbability(alpha1, alpha2, beta, source_data)
         n = 1300
         cp.set_n(n)
@@ -837,6 +731,7 @@ class ConditionalProbabilityTests(TestCase):
         self.assertEqual(cp.denominator_p_v, exp_denominator_p_v)
         self.assertEqual(cp.alpha2_n, exp_alpha2_n)
         self.assertEqual(cp.alpha2_n_tau, exp_alpha2_n_tau)
+
         np.testing.assert_array_almost_equal(cp.known_p_tv, exp_known_p_tv)
         np.testing.assert_array_almost_equal(cp.known_source_cp,
                                              exp_known_source_cp)
@@ -864,7 +759,6 @@ class ConditionalProbabilityTests(TestCase):
         for i in range(6):
             obs_jp_array[:, i] = self.cp.calculate_cp_slice(i, m_xiVs[i], m_V,
                                                             n_vnoti)
-
         np.testing.assert_array_almost_equal(obs_jp_array, exp_jp_array)
 
         # Test using Dan's R code and some print statements. Using the same
@@ -940,8 +834,8 @@ class TestGibbs(TestCase):
         alpha1 = .2
         alpha2 = .1
         beta = 3
-        source_data = np.array([[0, 1, 4, 10],
-                                [3, 2, 1, 1]])
+        source_data = csr_matrix(np.array([[0, 1, 4, 10],
+                                           [3, 2, 1, 1]]))
         sink = np.array([2, 1, 4, 2])
 
         # Make calculations using gibbs function.
@@ -1018,8 +912,8 @@ class TestGibbs(TestCase):
         features = ['o1', 'o2', 'o3', 'o4', 'o5', 'o6']
         source1 = np.array([10, 10, 10, 0, 0, 0])
         source2 = np.array([0, 0, 0, 10, 10, 10])
-        sources = pd.DataFrame(np.vstack((source1, source2)).astype(np.int32),
-                               index=['source1', 'source2'], columns=features)
+        sources = dtot(pd.DataFrame(np.vstack((source1, source2)).astype(np.int32),
+                               index=['source1', 'source2'], columns=features))
         self.assertRaises(ValueError, gibbs, sources, alpha1=-.3)
 
     def test_gibbs_data_bad(self):
@@ -1027,35 +921,26 @@ class TestGibbs(TestCase):
         features = ['o1', 'o2', 'o3', 'o4', 'o5', 'o6']
         source1 = np.array([10, 10, 10, 0, 0, np.nan])
         source2 = np.array([0, 0, 0, 10, 10, 10])
-        sources = pd.DataFrame(np.vstack((source1, source2)),
-                               index=['source1', 'source2'], columns=features)
+        sources = dtot(pd.DataFrame(np.vstack((source1, source2)),
+                               index=['source1', 'source2'], columns=features))
         self.assertRaises(ValueError, gibbs, sources)
 
         # features do not overlap.
         features = ['o1', 'o2', 'o3', 'o4', 'o5', 'o6']
         source1 = np.array([10, 10, 10, 0, 0, 0])
         source2 = np.array([0, 0, 0, 10, 10, 10])
-        sources = pd.DataFrame(np.vstack((source1, source2)),
-                               index=['source1', 'source2'], columns=features)
+        sources = dtot(pd.DataFrame(np.vstack((source1, source2)),
+                               index=['source1', 'source2'], columns=features))
         features2 = ['o1', 'asdsadO2', 'o3', 'o4', 'o5', 'o6']
         sink1 = np.array([10, 10, 10, 0, 0, 0])
         sink2 = np.array([0, 0, 0, 10, 10, 10])
-        sinks = pd.DataFrame(np.vstack((sink1, sink2)),
-                             index=['sink1', 'sink2'], columns=features2)
+        sinks = dtot(pd.DataFrame(np.vstack((sink1, sink2)),
+                             index=['sink1', 'sink2'], columns=features2))
         self.assertRaises(ValueError, gibbs, sources, sinks)
 
         # there are negative counts.
-        sources.iloc[0, 2] = -10
+        sources.matrix_data[0, 2] = -10
         self.assertRaises(ValueError, gibbs, sources)
-
-        # non-real data in input dataframe.
-        # copied from test of `validate_gibbs_input`.
-        data = np.random.randint(0, 10, size=20).reshape(5, 4)
-        sources = pd.DataFrame(data.astype(np.int32),
-                               index=['f%s' % i for i in range(5)],
-                               columns=['s%s' % i for i in range(4)])
-        sources.iloc[2, 2] = '3.a'
-        self.assertRaises(ValueError, validate_gibbs_input, sources)
 
     def test_consistency_when_gibbs_seeded(self):
         '''Test consistency of `gibbs` (without LOO) from run to run.
@@ -1077,10 +962,10 @@ class TestGibbs(TestCase):
         source1 = np.array([10, 10, 10, 0, 0, 0])
         source2 = np.array([0, 0, 0, 10, 10, 10])
         sink1 = .5*source1 + .5*source2
-        sinks = pd.DataFrame(sink1.reshape(1, 6).astype(np.int32),
-                             index=['sink1'], columns=features)
-        sources = pd.DataFrame(np.vstack((source1, source2)).astype(np.int32),
-                               index=['source1', 'source2'], columns=features)
+        sinks = dtot(pd.DataFrame(sink1.reshape(1, 6).astype(np.int32),
+                             index=['sink1'], columns=features).T)
+        sources = dtot(pd.DataFrame(np.vstack((source1, source2)).astype(np.int32),
+                               index=['source1', 'source2'], columns=features).T)
 
         np.random.seed(1042)
         mpm, mps, fts = gibbs(sources, sinks, alpha1=.001, alpha2=.01, beta=1,
@@ -1128,7 +1013,8 @@ class TestGibbs(TestCase):
                           source2b)).astype(np.int32)
         source_names = ['source1a', 'source1b', 'source2a', 'source2b']
         feature_names = ['o1', 'o2', 'o3', 'o4', 'o5', 'o6']
-        sources = pd.DataFrame(vals, index=source_names, columns=feature_names)
+        sources = dtot(pd.DataFrame(vals, index=source_names,
+                                    columns=feature_names).T)
 
         np.random.seed(1042)
         obs_mpm, obs_mps, obs_fts = gibbs(sources, sinks=None, alpha1=.001,
@@ -1171,8 +1057,8 @@ class TestGibbs(TestCase):
                               [0, 0, 0, 0, 0, 0],
                               [5, 9, 4, 7, 15, 9]])
         fts_vals = [fts0_vals, fts1_vals, fts2_vals, fts3_vals]
-        exp_fts = [pd.DataFrame(vals, index=source_names + ['Unknown'],
-                   columns=feature_names) for vals in fts_vals]
+        exp_fts = [dtot(pd.DataFrame(vals, index=source_names + ['Unknown'],
+                   columns=feature_names)) for vals in fts_vals]
 
         pd.util.testing.assert_frame_equal(obs_mpm, exp_mpm)
         pd.util.testing.assert_frame_equal(obs_mps, exp_mps)
@@ -1198,8 +1084,8 @@ class TestGibbs(TestCase):
                      dtype=np.int32)
         sources_names = ['source1', 'source2', 'source3']
         feature_names = ['f%i' % i for i in range(32)]
-        sources = pd.DataFrame(sources_data, index=sources_names,
-                               columns=feature_names)
+        sources = dtot(pd.DataFrame(sources_data, index=sources_names,
+                               columns=feature_names).T)
 
         sinks_data = np.array([[0, 0, 0, 0, 0, 0, 170, 0, 0, 0, 0, 0, 0, 0, 0,
                                 0, 0, 0, 385, 0, 0, 0, 0, 0, 0, 0, 350, 0, 0,
@@ -1214,8 +1100,8 @@ class TestGibbs(TestCase):
                                 0, 0, 0, 386, 0, 0, 0, 0, 0, 0, 0, 350, 0, 0,
                                 0, 0, 94]], dtype=np.int32)
         sinks_names = ['sink1', 'sink2', 'sink3', 'sink4']
-        sinks = pd.DataFrame(sinks_data, index=sinks_names,
-                             columns=feature_names)
+        sinks = dtot(pd.DataFrame(sinks_data, index=sinks_names,
+                             columns=feature_names).T)
 
         obs_mpm, obs_mps, _ = gibbs(sources, sinks, alpha1=.001, alpha2=.1,
                                     beta=10, restarts=2, draws_per_restart=2,

--- a/sourcetracker/tests/test_util.py
+++ b/sourcetracker/tests/test_util.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as pdt
 
-from sourcetracker._util import parse_sample_metadata, biom_to_df
+from sourcetracker._util import parse_sample_metadata
 
 
 class ParseSampleMetadata(unittest.TestCase):
@@ -30,21 +30,6 @@ class ParseSampleMetadata(unittest.TestCase):
                                 index=pd.Index(['01', '00'], name='#SampleID'),
                                 columns=['Col1', 'Col2'])
         pdt.assert_frame_equal(observed, expected)
-
-
-class BiomToDF(unittest.TestCase):
-
-    def test_convert(self):
-        exp = pd.DataFrame(np.arange(200).reshape(20, 10).astype(np.float64).T,
-                           index=['s%s' % i for i in range(10)],
-                           columns=['o%s' % i for i in range(20)])
-
-        data = np.arange(200).reshape(20, 10).astype(np.float64)
-        oids = ['o%s' % i for i in range(20)]
-        sids = ['s%s' % i for i in range(10)]
-
-        obs = biom_to_df(Table(data, oids, sids))
-        pd.util.testing.assert_frame_equal(obs, exp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
SourceTracker2 regrettably relied on a `DataFrame` transformation of a `biom.Table` early in its processing leading to substantial resource requirements stemming from the resulting dense matrix. 

This pull request fixes SourceTracker2 to use `biom.Table` for upstream processing and deferring until the last point for a dense transformation. On a large data, we observed a 2.33x reduction in runtime and a 5.59x reduction in memory used. 

The results are qualitatively identical to "vanilla" SourceTracker2 relative to the predicted environments. 

Note that three tests are failing in SourceTracker2 master, two of which are almost certainly related to changes in NumPy's random number generator and I suspect are sensitive to the seed. The third test was an actual bug that was fixed while adjusting unit tests

I'm uncertain whether it is technically correct to make the inner loop sparse. The use of `alpha1` necessitates a dense matrix as it adds a small prior to all features even the zero'd ones. If that is not necessary, then the inner loop can be made sparse which will yield further gains. Note that the unit tests assume `alpha1` is applied everywhere though so it would require modifying some of the unit tests. 

cc @wdwvt1 @rob-knight 